### PR TITLE
Revert "Try pinning to Python 3.13.0 in CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', 3.13.0]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Reverts adamtheturtle/doccmd#238

Pylint is now fixed -  https://github.com/pylint-dev/astroid/pull/2267#issuecomment-1666642781