### PR TITLE
Update README.rst pre-commit rev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ To run ``doccmd`` with `pre-commit`_, add hooks like the following to your ``.pr
 .. code-block:: yaml
 
    -   repo: https://github.com/adamtheturtle/doccmd-pre-commit
-       rev: v2025.04.08
+       rev: v2025.4.8
        hooks:
        -   id: doccmd
            args: ["--language", "shell", "--command", "shellcheck --shell=bash"]


### PR DESCRIPTION
Thanks for the useful repo!

The pre-commit instructions as they are right now will fail with:
```
[INFO] Initializing environment for https://github.com/adamtheturtle/doccmd-pre-commit.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v2025.04.08')
return code: 1
stdout: (none)
stderr:
    error: pathspec 'v2025.04.08' did not match any file(s) known to git
Check the log at /home/anil/.cache/pre-commit/pre-commit.log
```

This is due to difference in the way the the revision is named. This PR fixes the discrepancy.

Updates rev: v2025.04.08 to rev: v2025.4.8 to agree with https://github.com/adamtheturtle/doccmd-pre-commit