### PR TITLE
Add --no-write-to-file flag for read-only doccmd commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,8 +117,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uv run --extra=dev doccmd --language=shell --language=console --command="shellcheck
-          --shell=bash"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
+          --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -153,7 +153,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -178,7 +178,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --language=python --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -194,7 +194,7 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --language=python --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -227,7 +227,7 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --language=python --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -285,7 +285,7 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --language=python --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
## Summary
- Add `--no-write-to-file` flag to doccmd invocations that use read-only tools (shellcheck, mypy, pyright, vulture, pylint, interrogate)
- Tools that write to files (shfmt --write, ruff check --fix, ruff format) are intentionally not changed

## Test plan
- Pre-commit hooks pass
- Read-only checks work correctly with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --no-write-to-file to doccmd invocations for read-only hooks (shellcheck, mypy, pyright, vulture, pylint, interrogate).
> 
> - **Pre-commit config (`.pre-commit-config.yaml`)**:
>   - **Doc hooks now read-only via `--no-write-to-file`**:
>     - `shellcheck-docs`: `doccmd --no-write-to-file ... --command="shellcheck --shell=bash"`
>     - `mypy-docs`: `doccmd --no-write-to-file --command="mypy"`
>     - `pyright-docs`: `doccmd --no-write-to-file --command="pyright"`
>     - `vulture-docs`: `doccmd --no-write-to-file --command="vulture"`
>     - `pylint-docs`: `doccmd --no-write-to-file --command="pylint"`
>     - `interrogate-docs`: `doccmd --no-write-to-file --command="interrogate"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b72fe920864ac1a3bbbd4adf9b9868d25ccd17a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->