### PR TITLE
Use locking to prevent race conditions in parallel modes

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -380,12 +380,18 @@ def _evaluate_document(
     *,
     document: Document,
     example_workers: int,
+    has_grouping: bool,
 ) -> None:
-    """
-    Evaluate the document.
+    """Evaluate the document.
+
+    Args:
+        document: The document to evaluate.
+        example_workers: Number of workers for parallel execution.
+        has_grouping: Whether grouped examples are present. When True,
+            parallel execution is disabled to maintain document order.
     """
     examples = tuple(document.examples())
-    if example_workers == 1 or len(examples) in {0, 1}:
+    if example_workers == 1 or len(examples) in {0, 1} or has_grouping:
         for example in examples:
             example.evaluate()
         return
@@ -594,6 +600,7 @@ def _process_file_path(
             _evaluate_document(
                 document=document,
                 example_workers=example_workers,
+                has_grouping=bool(group_directives),
             )
         except _GroupModifiedError as exc:
             if fail_on_group_write:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disable parallel evaluation of examples whenever group directives are detected to preserve document order and avoid races.
> 
> - **Execution behavior**:
>   - `src/doccmd/__init__.py`:
>     - Update `_evaluate_document(document, example_workers, has_grouping)` to accept `has_grouping` and run serially when grouping is present.
>     - Pass `has_grouping=bool(group_directives)` at call site so grouped examples force non-parallel execution.
>     - Improve `_evaluate_document` docstring to reflect new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5476fb3c523b7e6f571ef10a76850494d2e4fb1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->