### PR TITLE
Add support for MyST code-cell directive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Next
 ----
 
+* Add support for MyST ``code-cell`` directive.
+
 2025.11.20
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,10 @@ To treat them as Markdown, use ``--myst-extension=. --markdown-extension=.md``.
    echo "Or this Hello, world!"
    ```
 
+   ```{code-cell} shell
+   echo "Or this code-cell!"
+   ```
+
 * Want more? Open an issue!
 
 Formatters and padding

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,10 @@ What does it work on?
    echo "Hello, world!"
    ```
 
+   ```{code-cell} shell
+   echo "Or this code-cell!"
+   ```
+
 * Want more? Open an issue!
 
 Formatters and padding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "click-compose>=2025.10.27.3",
     "cloup>=3.0.0",
     "pygments>=2.18.0",
-    "sybil>=9.1.0,<10.0.0",
+    "sybil>=9.3.0,<10.0.0",
     # Pin this dependency as we expect:
     # * It might have breaking changes
     # * It is not a direct dependency of the user

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -456,6 +456,10 @@ def test_multiple_files_multiple_types(tmp_path: Path) -> None:
         ```{code} python
         print("In MyST code")
         ```
+
+        ```{code-cell} python
+        print("In MyST code-cell")
+        ```
         """,
     )
     rst_file.write_text(data=rst_content, encoding="utf-8")
@@ -483,6 +487,7 @@ def test_multiple_files_multiple_types(tmp_path: Path) -> None:
         print("In simple markdown code block")
         print("In MyST code-block")
         print("In MyST code")
+        print("In MyST code-cell")
         """,
     )
 


### PR DESCRIPTION
This PR adds support for the MyST `code-cell` directive, which is commonly used in MyST markdown for Jupyter notebook-style code cells.

## Changes

- Update Sybil dependency to 9.3.0+ (includes support from https://github.com/simplistix/sybil/pull/158)
- Add test coverage for `code-cell` in `test_multiple_files_multiple_types`
- Update documentation (README.rst, docs/source/index.rst) with `code-cell` examples
- Update CHANGELOG

## Testing

All 110 tests pass, including the new test for `code-cell` directive support.

Closes #609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add support for MyST `code-cell` directive, update docs/tests, and bump Sybil to >=9.3.0.
> 
> - **Feature**: Support MyST `code-cell` directive
>   - Handle MyST ``{code-cell}`` blocks alongside ``{code-block}`` and ``{code}``.
> - **Tests**:
>   - Update `tests/test_doccmd.py::test_multiple_files_multiple_types` to include `code-cell` and expected output.
> - **Docs**:
>   - Add `code-cell` examples in `README.rst` and `docs/source/index.rst`.
> - **Dependencies**:
>   - Bump `sybil` to `>=9.3.0,<10.0.0` in `pyproject.toml`.
> - **Changelog**:
>   - Note `code-cell` support in `CHANGELOG.rst`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d951d8628d1e7721941568b6c6733c88b79aa421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->