### PR TITLE
Demonstrate in a test that MDX code blocks with parameters are parsed

### DIFF
--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -2981,6 +2981,48 @@ def test_mdx(tmp_path: Path) -> None:
     assert result.stderr == ""
 
 
+def test_mdx_parametrized_code_blocks(tmp_path: Path) -> None:
+    """
+    MDX code blocks with parameters (like title) are correctly parsed.
+    """
+    runner = CliRunner()
+    source_file = tmp_path / "example.mdx"
+    content = textwrap.dedent(
+        text="""\
+        ```python showLineNumbers title="world.py"
+        print("hello from python")
+        ```
+
+        ```js title="script.js"
+        console.log("javascript");
+        ```
+        """,
+    )
+    source_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--no-pad-file",
+        "--command",
+        "cat",
+        str(object=source_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    expected_output = textwrap.dedent(
+        text="""\
+        print("hello from python")
+        """,
+    )
+    assert result.stdout == expected_output
+    assert result.stderr == ""
+
+
 def test_directory(tmp_path: Path) -> None:
     """
     All source files in a given directory are worked on.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a test validating MDX code fences with parameters (e.g., title, showLineNumbers) are parsed correctly and language-filtered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4e2af3fff4952930a9c593aafeb8c7dc842d8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->