### PR TITLE
Make line numbers cmd-clickable in verbose mode

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -93,7 +93,7 @@ class _LogCommandEvaluator:
         )
         running_command_message = (
             f"Running '{command_str}' on code block at "
-            f"{example.path} line {example.line}"
+            f"{example.path}:{example.line}"
         )
         _log_info(message=running_command_message)
 

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1297,7 +1297,7 @@ def test_verbose_running(tmp_path: Path) -> None:
     expected_stderr = textwrap.dedent(
         text=f"""\
         {fg.green}Not using PTY for running commands.{reset}
-        {fg.green}Running 'cat' on code block at {rst_file} line 1{reset}
+        {fg.green}Running 'cat' on code block at {rst_file}:1{reset}
         """,
     )
     assert result.stdout == expected_output
@@ -1363,11 +1363,11 @@ def test_verbose_running_with_stderr(tmp_path: Path) -> None:
     expected_stderr = textwrap.dedent(
         text=f"""\
         {fg.green}Not using PTY for running commands.{reset}
-        {fg.green}Running '{command}' on code block at {rst_file} line 1{reset}
+        {fg.green}Running '{command}' on code block at {rst_file}:1{reset}
         error
-        {fg.green}Running '{command}' on code block at {rst_file} line 19{reset}
+        {fg.green}Running '{command}' on code block at {rst_file}:19{reset}
         error
-        """,  # noqa: E501
+        """,
     )
     assert result.stdout == expected_output
     assert result.stderr == expected_stderr


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch verbose log format from "path line N" to "path:N" and update tests accordingly.
> 
> - **Verbose logging**:
>   - Change `_LogCommandEvaluator` message from `path line N` to `path:N` in `src/doccmd/__init__.py`.
> - **Tests**:
>   - Update expectations in `tests/test_doccmd.py` to match `path:N` format in verbose outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35bf2014ba49a8dbc301a5e4d61e5c860543ab41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->