### PR TITLE
Add documentation for --group-mdx-by-attribute option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,41 +255,6 @@ For example, if we used ``doccmd`` with ``--language=shell`` and ``--skip-marker
 Grouping code blocks
 --------------------
 
-Grouping by MDX attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``--group-mdx-by-attribute`` option groups MDX code blocks by the value of a specified attribute.
-Code blocks with the same attribute value are grouped together and executed as a single unit.
-This is useful for working with MDX files that follow conventions like Docusaurus, where code blocks are grouped using custom attributes.
-
-For example, with ``--group-mdx-by-attribute=group``, these blocks are grouped by their ``group`` attribute value:
-
-.. code-block:: markdown
-
-   ```python group="example1"
-   def my_function():
-       return "Hello"
-   ```
-
-   ```python group="example2"
-   def other_function():
-       return "World"
-   ```
-
-   ```python group="example1"
-   result = my_function()
-   ```
-
-In this example, the first and third code blocks (both with ``group="example1"``) are grouped together and executed as one unit, while the second block (with ``group="example2"``) is processed separately.
-
-Code blocks without the specified attribute are processed individually as normal.
-
-This option only applies to MDX files and follows the same restrictions as other grouping methods:
-
-* Error messages may include lines that don't match the document
-* Code formatters may not work correctly
-* Changes to code blocks are not written back to the file
-
 Automatic file-level grouping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -316,12 +281,6 @@ For example, with ``--group-file``, these blocks work together without any speci
    my_function()
 
 .. group doccmd[all]: end
-
-When using ``--group-file``, the same restrictions apply as with manual grouping:
-
-* Error messages may include lines that don't match the document
-* Code formatters may not work correctly
-* Changes to code blocks are not written back to the file
 
 Manual grouping with directives
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -354,6 +313,37 @@ Error messages for grouped code blocks may include lines which do not match the 
 
 Use the ``--group-marker`` option to set a marker for this particular command which will work as well as ``all``.
 For example, use ``--group-marker="type-check"`` to group code blocks which come between comments matching ``group doccmd[type-check]: start`` and ``group doccmd[type-check]: end``.
+
+Grouping by MDX attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``--group-mdx-by-attribute`` option groups MDX code blocks by the value of a specified attribute.
+Code blocks with the same attribute value are grouped together and executed as a single unit.
+This is useful for working with MDX files that follow conventions like Docusaurus, where code blocks are grouped using custom attributes.
+
+For example, with ``--group-mdx-by-attribute=group``, these blocks are grouped by their ``group`` attribute value:
+
+.. code-block:: markdown
+
+   ```python group="example1"
+   def my_function():
+       return "Hello"
+   ```
+
+   ```python group="example2"
+   def other_function():
+       return "World"
+   ```
+
+   ```python group="example1"
+   result = my_function()
+   ```
+
+In this example, the first and third code blocks (both with ``group="example1"``) are grouped together and executed as one unit, while the second block (with ``group="example2"``) is processed separately.
+
+Code blocks without the specified attribute are processed individually as normal.
+
+This option only applies to MDX files.
 
 .. _using_groups_with_formatters:
 

--- a/docs/source/group-code-blocks.rst
+++ b/docs/source/group-code-blocks.rst
@@ -1,41 +1,6 @@
 Grouping code blocks
 --------------------
 
-Grouping by MDX attributes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :option:`doccmd --group-mdx-by-attribute` option groups MDX code blocks by the value of a specified attribute.
-Code blocks with the same attribute value are grouped together and executed as a single unit.
-This is useful for working with MDX files that follow conventions like Docusaurus, where code blocks are grouped using custom attributes.
-
-For example, with :option:`doccmd --group-mdx-by-attribute` set to ``"group"``, these blocks are grouped by their ``group`` attribute value:
-
-.. code-block:: markdown
-
-   ```python group="example1"
-   def my_function():
-       return "Hello"
-   ```
-
-   ```python group="example2"
-   def other_function():
-       return "World"
-   ```
-
-   ```python group="example1"
-   result = my_function()
-   ```
-
-In this example, the first and third code blocks (both with ``group="example1"``) are grouped together and executed as one unit, while the second block (with ``group="example2"``) is processed separately.
-
-Code blocks without the specified attribute are processed individually as normal.
-
-This option only applies to MDX files and follows the same restrictions as other grouping methods:
-
-* Error messages may include lines that don't match the document
-* Code formatters may not work correctly
-* Changes to code blocks are not written back to the file
-
 Automatic file-level grouping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,12 +27,6 @@ For example, with :option:`doccmd --group-file`, these blocks work together with
    my_function()
 
 .. group doccmd[all]: end
-
-Note that when using :option:`doccmd --group-file`, the same restrictions apply as with manual grouping:
-
-* Error messages may include lines that don't match the document
-* Code formatters may not work correctly
-* Changes to code blocks are not written back to the file
 
 Manual grouping with directives
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,6 +59,37 @@ Error messages for grouped code blocks may include lines which do not match the 
 
 Use the :option:`doccmd --group-marker` option to set a marker for this particular command which will work as well as ``all``.
 For example, set :option:`doccmd --group-marker` to ``"type-check"`` to group code blocks which come between comments matching ``group doccmd[type-check]: start`` and ``group doccmd[type-check]: end``.
+
+Grouping by MDX attributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :option:`doccmd --group-mdx-by-attribute` option groups MDX code blocks by the value of a specified attribute.
+Code blocks with the same attribute value are grouped together and executed as a single unit.
+This is useful for working with MDX files that follow conventions like Docusaurus, where code blocks are grouped using custom attributes.
+
+For example, with :option:`doccmd --group-mdx-by-attribute` set to ``"group"``, these blocks are grouped by their ``group`` attribute value:
+
+.. code-block:: markdown
+
+   ```python group="example1"
+   def my_function():
+       return "Hello"
+   ```
+
+   ```python group="example2"
+   def other_function():
+       return "World"
+   ```
+
+   ```python group="example1"
+   result = my_function()
+   ```
+
+In this example, the first and third code blocks (both with ``group="example1"``) are grouped together and executed as one unit, while the second block (with ``group="example2"``) is processed separately.
+
+Code blocks without the specified attribute are processed individually as normal.
+
+This option only applies to MDX files.
 
 .. _using_groups_with_formatters:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds docs for --group-mdx-by-attribute with examples and removes the prior group-file restrictions note.
> 
> - **Documentation**:
>   - **MDX grouping**: Add a new section explaining `--group-mdx-by-attribute`, with an example and notes that it applies only to MDX (`README.rst`, `docs/source/group-code-blocks.rst`).
>   - **Cleanup**: Remove the previous note listing restrictions under `--group-file` automatic grouping in both files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf7eb4db4b11c5528f29b395fe71367b49004e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->