### PR TITLE
Add error checks for gha-find-replace modifiedFiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 ---
-
 name: Release
 
 on: workflow_dispatch
@@ -63,6 +62,7 @@ jobs:
           echo "underline=${underline}" >> "$GITHUB_OUTPUT"
 
       - name: Update changelog
+        id: update_changelog
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
@@ -70,6 +70,13 @@ jobs:
             \ }}"
           include: CHANGELOG.rst
           regex: false
+
+      - name: Check changelog was modified
+        run: |
+          if [ "${{ steps.update_changelog.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating changelog"
+            exit 1
+          fi
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
@@ -133,12 +140,20 @@ jobs:
             uv run --no-cache --with="doccmd==${{ steps.calver.outputs.release }}" --extra=release poet --formula doccmd > ${{ steps.set-homebrew-filename.outputs.filename }}
 
       - name: Update Homebrew description
+        id: update_homebrew_description
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: desc "Shiny new formula"
           replace: desc "Run tools against code blocks in documentation"
           include: ${{ steps.set-homebrew-filename.outputs.filename }}
           regex: false
+
+      - name: Check Homebrew description was modified
+        run: |
+          if [ "${{ steps.update_homebrew_description.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating Homebrew description"
+            exit 1
+          fi
 
       - name: Push Homebrew Recipe
         uses: dmnemec/copy_file_to_another_repo_action@main
@@ -157,12 +172,20 @@ jobs:
           commit_message: Bump CLI Homebrew recipe
 
       - name: Update README versions
+        id: update_readme_versions
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: ${{ steps.get_current_version.outputs.version }}
           replace: ${{ steps.calver.outputs.release }}
           include: README.rst
           regex: false
+
+      - name: Check README was modified
+        run: |
+          if [ "${{ steps.update_readme_versions.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating README versions"
+            exit 1
+          fi
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit-readme


### PR DESCRIPTION
Fail the workflow if no files are modified during:
- Changelog updates
- Homebrew description updates  
- README version updates

This catches cases where find/replace patterns don't match, preventing silent failures in the release process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add checks in release workflow to error if CHANGELOG, Homebrew formula, or README replacements modify 0 files.
> 
> - **CI (GitHub Actions)**: `/.github/workflows/release.yml`
>   - Add step IDs for `update_changelog`, `update_homebrew_description`, and `update_readme_versions`.
>   - Insert validation steps to fail the job if `gha-find-replace` reports `modifiedFiles=0` for:
>     - `CHANGELOG.rst` update
>     - Homebrew formula description update
>     - `README.rst` version update
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d86944255e4d223450de2a525039536971d09510. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->