### PR TITLE
Fix release workflow to handle different version formats

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
-      - name: Get current version
-        id: get_current_version
-        run: |
-          version="$(git describe --tags --abbrev=0)"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
       - name: Calver calculate version
         uses: StephaneBour/actions-calver@master
         id: calver
@@ -171,19 +165,35 @@ jobs:
           user_name: adamtheturtle
           commit_message: Bump CLI Homebrew recipe
 
-      - name: Update README versions
-        id: update_readme_versions
+      - name: Update Linux binary version
+        id: update_linux_binary
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: ${{ steps.get_current_version.outputs.version }}
-          replace: ${{ steps.calver.outputs.release }}
+          find: (releases/download/)[0-9]+\.[0-9]+\.[0-9]+
+          replace: $1${{ steps.tag_version.outputs.new_tag }}
           include: README.rst
-          regex: false
+          regex: true
 
-      - name: Check README was modified
+      - name: Check Linux binary version was modified
         run: |
-          if [ "${{ steps.update_readme_versions.outputs.modifiedFiles }}" = "0" ]; then
-            echo "Error: No files were modified when updating README versions"
+          if [ "${{ steps.update_linux_binary.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating Linux binary version"
+            exit 1
+          fi
+
+      - name: Update pre-commit rev
+        id: update_precommit_rev
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '(rev: )v[0-9]+\.[0-9]+\.[0-9]+'
+          replace: $1v${{ steps.tag_version.outputs.new_tag }}
+          include: README.rst
+          regex: true
+
+      - name: Check pre-commit rev was modified
+        run: |
+          if [ "${{ steps.update_precommit_rev.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating pre-commit rev"
             exit 1
           fi
 


### PR DESCRIPTION
The release process was not accounting for the different version formatting requirements between the Linux binary URL and the pre-commit rev in README.rst.

**Issue:**
- Linux binary URL uses the full version format: `2025.12.08`
- Pre-commit rev uses version with `v` prefix: `v2025.4.8`
- The workflow was doing a simple find-replace that couldn't handle both formats

**Solution:**
- Removed unused 'Get current version' step
- Replaced single version update with two separate regex-based updates:
  - Linux binary URL: uses tag version without prefix
  - Pre-commit rev: uses tag version with 'v' prefix  
- Both now use `steps.tag_version.outputs.new_tag` for consistency
- Each update has its own validation check

Inspired by the approach used in the doccmd-pre-commit workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split README updates into two regex-based steps (Linux binary URL and pre-commit rev) using the tag version, each with its own validation; removed unused current-version step.
> 
> - **CI/Release Workflow (`.github/workflows/release.yml`)**
>   - Remove unused `Get current version` step.
>   - Add separate regex-based README updates:
>     - Update Linux binary URL version: replace `(releases/download/)X.Y.Z` with `$1${{ steps.tag_version.outputs.new_tag }}`.
>     - Update pre-commit `rev`: replace `(rev: )vX.Y.Z` with `$1v${{ steps.tag_version.outputs.new_tag }}`.
>   - Add individual checks to ensure each update modified files.
>   - Continue committing README changes via `git-auto-commit-action`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c56b312e093f31371df73137f07eed717ad6280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->