### PR TITLE
Fix CalVer version format in README and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
         id: update_linux_binary
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: (releases/download/)[0-9]+\.[0-9]+\.[0-9]+
+          find: (releases/download/)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+
           replace: $1${{ steps.tag_version.outputs.new_tag }}
           include: README.rst
           regex: true
@@ -185,7 +185,7 @@ jobs:
         id: update_precommit_rev
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: '(rev: )v[0-9]+\.[0-9]+\.[0-9]+'
+          find: '(rev: )v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
           replace: $1v${{ steps.tag_version.outputs.new_tag }}
           include: README.rst
           regex: true

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Pre-built Linux (x86) binaries
 
 .. code-block:: console
 
-   $ curl --fail -L https://github.com/adamtheturtle/doccmd/.12.08.1/doccmd-linux -o /usr/local/bin/doccmd &&
+   $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2024.12.08.1/doccmd-linux -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
 Using ``doccmd`` as a pre-commit hook
@@ -49,7 +49,7 @@ To run ``doccmd`` with `pre-commit`_, add hooks like the following to your ``.pr
 .. code-block:: yaml
 
    -   repo: https://github.com/adamtheturtle/doccmd-pre-commit
-       .12.08.1
+       rev: v2024.12.08.1
        hooks:
        -   id: doccmd
            args: ["--language", "shell", "--command", "shellcheck --shell=bash"]


### PR DESCRIPTION
This PR fixes the version formatting issues in README.rst and the release workflow.

## Changes

### README.rst
- Fixed Linux binary download URL: Changed from `.12.08.1` to proper format `releases/download/2024.12.08.1`
- Fixed pre-commit rev: Changed from `.12.08.1` to proper format `rev: v2024.12.08.1`

### .github/workflows/release.yml
- Updated Linux binary version regex: Changed from `[0-9]+\.[0-9]+\.[0-9]+` to `[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+` to match 4-segment CalVer format (YYYY.MM.DD.PATCH)
- Updated pre-commit rev regex: Changed from `v[0-9]+\.[0-9]+\.[0-9]+` to `v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+` to match 4-segment CalVer format

These changes ensure the release workflow can correctly find and replace version numbers in the README when creating new releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust README links/revs and release workflow regexes to support 4-part CalVer (YYYY.MM.DD.PATCH).
> 
> - **Docs**:
>   - Update Linux binary URL and pre-commit `rev` in `README.rst` to `releases/download/2024.12.08.1` and `v2024.12.08.1`.
> - **CI/Release** (`.github/workflows/release.yml`):
>   - Broaden version-matching regex for README updates to four-part CalVer: `find: (releases/download/)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+` and `find: '(rev: )v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad5afe72cb3530bed32393498768229613cb653. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->