### PR TITLE
Use CalVer to generate pre-commit version without leading zeros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,15 @@ jobs:
           user_name: adamtheturtle
           commit_message: Bump CLI Homebrew recipe
 
+      - name: Calculate version without leading zeros for pre-commit
+        uses: StephaneBour/actions-calver@master
+        id: calver_stripped
+        with:
+          date_format: '%Y.%-m.%-d'
+          release: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Update Linux binary version
         id: update_linux_binary
         uses: jacobtomlinson/gha-find-replace@v3
@@ -185,8 +194,8 @@ jobs:
         id: update_precommit_rev
         uses: jacobtomlinson/gha-find-replace@v3
         with:
-          find: '(rev: )v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
-          replace: ${1}v${{ steps.tag_version.outputs.new_tag }}
+          find: '(rev: )v[0-9]+\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]+)?'
+          replace: ${1}v${{ steps.calver_stripped.outputs.release }}
           include: README.rst
           regex: true
 


### PR DESCRIPTION
The pre-commit rev in README.rst references doccmd-pre-commit versions, which strip leading zeros (e.g., v2025.12.8 not v2025.12.08).

Added a CalVer step with date_format '%Y.%-m.%-d' to generate the version without leading zeros, and updated the pre-commit rev replacement to use this stripped version.

Also updated the regex to use {1,2} quantifiers to match both single and double-digit months/days.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute a CalVer without leading zeros for pre-commit and update the README rev replacement to use it with a regex that matches 1–2 digit months/days.
> 
> - **CI/Release workflow (`.github/workflows/release.yml`)**:
>   - Add CalVer step (`calver_stripped`) using `'%Y.%-m.%-d'` to produce a version without leading zeros for pre-commit.
>   - Update pre-commit rev replacement in `README.rst` to use `calver_stripped.outputs.release` and broaden regex to match 1–2 digit months/days (`{1,2}`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b32d08d29f33c4d9d1e25cc90c9798ab1953297. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->