### PR TITLE
Fix: Strip leading zeros from full tag including patch number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,14 +165,24 @@ jobs:
           user_name: adamtheturtle
           commit_message: Bump CLI Homebrew recipe
 
-      - name: Calculate version without leading zeros for pre-commit
-        uses: StephaneBour/actions-calver@master
+      - name: Strip leading zeros from version for pre-commit
         id: calver_stripped
-        with:
-          date_format: '%Y.%-m.%-d'
-          release: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Take the tag (e.g., v2025.12.08.4) and strip leading zeros from the calver part
+          tag="${{ steps.tag_version.outputs.new_tag }}"
+          calver="${{ steps.calver.outputs.release }}"
+
+          # Strip leading zeros from calver
+          IFS='.' read -r -a parts <<< "$calver"
+          stripped_parts=()
+          for part in "${parts[@]}"; do
+            stripped_parts+=("$((10#$part))")
+          done
+          stripped_calver="$(IFS='.'; echo "${stripped_parts[*]}")"
+
+          # Replace the calver part in the tag
+          stripped_tag="${tag/$calver/$stripped_calver}"
+          echo "tag=${stripped_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Update Linux binary version
         id: update_linux_binary
@@ -195,7 +205,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: '(rev: )v[0-9]+\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]+)?'
-          replace: ${1}v${{ steps.calver_stripped.outputs.release }}
+          replace: ${1}${{ steps.calver_stripped.outputs.tag }}
           include: README.rst
           regex: true
 


### PR DESCRIPTION
The previous approach only stripped zeros from the date part (YYYY.MM.DD) but ignored the patch number (.N).

Now we:
1. Take the full tag (e.g., v2025.12.08.4)
2. Strip leading zeros from the calver part (2025.12.08 -> 2025.12.8)
3. Replace the calver in the tag (v2025.12.08.4 -> v2025.12.8.4)

This ensures the pre-commit rev includes the full version with patch number.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace calver-based stripping with a shell step that removes leading zeros from the calver within the full tag and use that stripped tag when updating the pre-commit rev in README.
> 
> - **CI/Release (`.github/workflows/release.yml`)**:
>   - Replace the previous calver-stripping action with a shell step that strips leading zeros from the calver and reconstructs the full tag output (`calver_stripped.tag`).
>   - Update the README pre-commit rev replacement to use the new stripped full tag output, ensuring the patch number is preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac70c718c76db37371718ec335b4c2d7f93c820f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->