### PR TITLE
Fix regex capture group escaping and version formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           tag="${{ steps.tag_version.outputs.new_tag }}"
           # Strip leading zeros from each numeric segment (e.g., v2025.12.08.4 -> v2025.12.8.4)
-          stripped_tag=$(echo "$tag" | sed -E 's/\.0+([0-9])/.\1/g')
+          stripped_tag=$(echo "v$tag" | sed -E 's/\.0+([0-9])/.\1/g')
           echo "tag=${stripped_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Update Linux binary version


### PR DESCRIPTION
This PR fixes multiple issues with version formatting in the release workflow.

## Fixes

1. **Capture group escaping** (PR #640 feedback): Use `${1}` instead of `$1` to prevent GitHub Actions from interpreting it as an empty variable

2. **Support both 3 and 4 segment versions** (PR #640 feedback): Make the patch number optional in regex: `[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?`

3. **Handle single-digit months/days for pre-commit**: Use `{1,2}` quantifiers for pre-commit rev regex to match versions like `v2025.2.18`

4. **Strip leading zeros for pre-commit rev**: Convert `2025.12.08.4` to `v2025.12.8.4` for doccmd-pre-commit compatibility using `sed -E 's/\.0+([0-9])/.\1/g'`

5. **Add v prefix**: Ensure stripped version includes `v` prefix since `tag_prefix` is empty

## Related
- Addresses: https://github.com/adamtheturtle/doccmd/pull/640#discussion_r2597429400
- Addresses: https://github.com/adamtheturtle/doccmd/pull/643/files#r2597549176
- Related to: adamtheturtle/doccmd-pre-commit#170

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace calver-based step with a shell step to strip leading zeros and add `v`, and update README pre-commit rev replacement to use the new tag output.
> 
> - **CI (release workflow)**:
>   - Replace version-normalization step with a shell script that strips leading zeros and prepends `v`, outputting `tag` (`steps.calver_stripped.outputs.tag`).
>   - Update README pre-commit rev replacement to use `${1}${{ steps.calver_stripped.outputs.tag }}` instead of the previous release value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71bfc87eaa09d4a4efbd4bfa488d1943d6248a32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->