### PR TITLE
Add -W flag to docs hook for consistent error handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -322,7 +322,7 @@ repos:
 
       - id: docs
         name: Build Documentation
-        entry: uv run --extra=dev sphinx-build -M html docs/source docs/build
+        entry: uv run --extra=dev sphinx-build -M html docs/source docs/build -W
         language: python
         stages: [manual]
         pass_filenames: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the docs build hook fail on Sphinx warnings by adding the -W flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df097db06f0e2ec31f28f8ae865a1745cc5ba163. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->