### PR TITLE
Update sybil-extras version to 2025.12.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # Pin this dependency as we expect:
     # * It might have breaking changes
     # * It is not a direct dependency of the user
-    "sybil-extras==2025.12.10.2",
+    "sybil-extras==2025.12.10.3",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.9.24",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates pinned `sybil-extras` dependency in `pyproject.toml` from `2025.12.10.2` to `2025.12.10.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 789e929af3ae3c3af159021a26c29c2b55ec280b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->