### PR TITLE
Bump beartype to 0.22.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.19.0",
+    "beartype>=0.22.9",
     "charset-normalizer>=3.4.1",
     "click>=8.3.0,<8.4.0",
     "click-compose>=2025.10.27.3",


### PR DESCRIPTION
Bump beartype dependency to 0.22.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise `beartype` dependency floor to `>=0.22.9` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b7ce14cf6fe02b48f95d48ef142d5ed1fd2278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->