### PR TITLE
Bump sybil-extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # Pin this dependency as we expect:
     # * It might have breaking changes
     # * It is not a direct dependency of the user
-    "sybil-extras==2025.12.13.1",
+    "sybil-extras==2025.12.13.4",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.9.24",

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -3189,7 +3189,7 @@ def test_group_start_without_end(
     )
     expected_error = (
         f"{fg.red}Could not parse {rst_file}: "
-        "'group doccmd[all]: start' was not followed by "
+        "'group doccmd[all]: start' must be followed by "
         f"'group doccmd[all]: end'{reset}"
     )
     assert result.stderr == expected_error + "\n"
@@ -3221,6 +3221,7 @@ def test_group_nested_start_without_end(tmp_path: Path) -> None:
     rst_file.write_text(data=content, encoding="utf-8")
 
     arguments = [
+        "--fail-on-parse-error",
         "--language",
         "python",
         "--command",
@@ -3238,7 +3239,7 @@ def test_group_nested_start_without_end(tmp_path: Path) -> None:
         result.stderr,
     )
     expected_error = (
-        f"{fg.red}Error running command 'cat': "
+        f"{fg.red}Could not parse {rst_file}: "
         "'group doccmd[all]: start' must be followed by "
         f"'group doccmd[all]: end'{reset}"
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `sybil-extras` and updates tests to expect parse-error messaging for unclosed group directives, including adding `--fail-on-parse-error` where needed.
> 
> - **Dependencies**
>   - Pin `sybil-extras` to `2025.12.13.4` in `pyproject.toml`.
> - **Tests**
>   - Adjust expected error strings to use "must be followed by" and report `Could not parse ...` for unclosed `group doccmd[all]` directives in `tests/test_doccmd.py`.
>   - Add `--fail-on-parse-error` to the nested group test to assert parse failure behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d67b6b97b795a9036d0e70719f94be615a18e942. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->