### PR TITLE
Avoid deprecated write_to setuptools-scm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ universal = true
 # We write the version to a file so that we can import it.
 # We choose a ``.py`` file so that we can read it without
 # worrying about including the file in MANIFEST.in.
-write_to = "src/doccmd/_setuptools_scm_version.py"
+version_file = "src/doccmd/_setuptools_scm_version.py"
 # This keeps the start of the version the same as the last release.
 # This is useful for our documentation to include e.g. binary links
 # to the latest released binary.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace deprecated setuptools-scm `write_to` with `version_file` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9d5f81515e03a061785385619ef080149495a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->