### PR TITLE
Add pyrefly type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,8 @@ ci:
     - sphinx-lint
     - ty
     - ty-docs
+    - pyrefly
+    - pyrefly-docs
     - vulture
     - vulture-docs
     - yamlfix
@@ -355,6 +357,24 @@ repos:
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="ty check"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyrefly
+        name: pyrefly
+        stages: [pre-push]
+        entry: uv run --extra=dev pyrefly check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyrefly-docs
+        name: pyrefly-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ optional-dependencies.dev = [
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
     "pyproject-fmt==2.11.1",
+    "pyrefly==0.46.1",
     "pyright==1.1.407",
     "pyroma==5.0.1",
     "pytest==9.0.2",


### PR DESCRIPTION
## Summary
- Add pyrefly==0.46.1 to dev dependencies
- Add pyrefly and pyrefly-docs pre-commit hooks

## Test plan
- Run `pre-commit run pyrefly --all-files` to verify pyrefly works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates `pyrefly` type checking into tooling.
> 
> - Add `pyrefly==0.46.1` to `dev` dependencies in `pyproject.toml`
> - New pre-push hooks `pyrefly` and `pyrefly-docs` in `.pre-commit-config.yaml` to run `pyrefly check` on code and examples
> - Update `ci.skip` list to exclude `pyrefly` hooks from pre-commit CI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58589b35ab48cc686d12ad53fb2a50bebbbc5a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->