### PR TITLE
Make prettier more compatible with yamlfix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
       "files": ["*.yaml", "*.yml"],
       "options": {
         "singleQuote": true,
-        "printWidth": 100"
+        "printWidth": 100
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - Updates `.prettierrc` to set `printWidth: 100` for YAML (`*.yaml`, `*.yml`) overrides, retaining `singleQuote: true`, to align Prettier's YAML formatting with `yamlfix`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46b22e195e1d0aa66eacd93b18f0043e5bb8f8d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->