### PR TITLE
Fix zizmor warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           find: "Next\n----"
           replace: |-
-            "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n"
+            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the release workflow changelog insertion to avoid formatting issues.
> 
> - In `release.yml`, switches `gha-find-replace` `replace` value to a YAML block (`|-`) including a final `\n`, ensuring `CHANGELOG.rst` entry insertion (version + underline) includes a trailing newline and renders correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17521f421b0a10d0df3a26e74b82485c08eef9a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->