### PR TITLE
Make zizmor collection strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -370,7 +370,7 @@ repos:
 
       - id: zizmor
         name: zizmor
-        entry: uv run --extra=dev zizmor .github
+        entry: uv run --extra=dev zizmor --strict-collection .github
         language: python
         pass_filenames: false
         types_or: [yaml]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens policy checks in pre-commit.
> 
> - Updates `zizmor` hook in `.pre-commit-config.yaml` to run `zizmor --strict-collection .github` instead of the non-strict invocation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d54641f5f4d623ad88737768935661c53d7a2cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->