### PR TITLE
Fix zizmor warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}"
+          replace: |-
+            Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline }}\n
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use YAML block scalar syntax for replace field to fix zizmor warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI/Release workflow**
> 
> - Updates `.github/workflows/release.yml` to use a YAML block scalar (`|-`) for the `gha-find-replace` `replace` value in the changelog step, appending a trailing newline. No behavior changes beyond formatting of the replacement string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a71ad7f198be3eef869d313c2c83614f39759c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->