### PR TITLE
Remove uv version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Avoid https://github.com/astral-sh/uv/issues/12260.
-          version: 0.6.6
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          # Avoid https://github.com/astral-sh/uv/issues/12260.
-          version: 0.6.6
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 


### PR DESCRIPTION
The issue https://github.com/astral-sh/uv/issues/12260 has been fixed, so we no longer need to pin to version 0.6.6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the explicit `uv` version pin from GitHub Actions workflows to allow using the latest `uv`.
> 
> - In `ci.yml` and `release.yml`, drop `with: version: 0.6.6` and its related comment from the `astral-sh/setup-uv@v7` step; caching settings remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cac7cba1409a873d9b6a0ab2dedf9e34678d2867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->