### PR TITLE
Add Nix installation instructions to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Requires `Nix`_.
 To avoid passing ``--extra-experimental-features`` every time, `enable flakes`_ permanently.
 
 .. _Nix: https://nixos.org/download/
-.. _enable flakes: https://nixos.wiki/wiki/Flakes#Enable_flakes_permanently
+.. _enable flakes: https://wiki.nixos.org/wiki/Flakes#Enabling_flakes_permanently
 
 Or add to your flake inputs:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -44,7 +44,7 @@ Requires `Nix`_.
 To avoid passing ``--extra-experimental-features`` every time, `enable flakes`_ permanently.
 
 .. _Nix: https://nixos.org/download/
-.. _enable flakes: https://nixos.wiki/wiki/Flakes#Enable_flakes_permanently
+.. _enable flakes: https://wiki.nixos.org/wiki/Flakes#Enabling_flakes_permanently
 
 Or add to your flake inputs:
 


### PR DESCRIPTION
Add Nix installation instructions to docs/source/install.rst, matching the instructions already present in README.rst.

The instructions include:
- Command to run doccmd via nix with flakes
- Note about enabling flakes permanently
- Flake inputs example for adding doccmd as a dependency

A skip marker was added for shellcheck because the substitution variables (e.g., `|github-owner|`) contain pipe characters that confuse the linter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Nix installation guidance and minor README fixes.
> 
> - New **With Nix** section in `docs/source/install.rst` with `nix run` example (using substitutions), note on enabling flakes, and flake inputs snippet
> - README tweaks: quote `nix run` target (`"github:..."`) and update `enable flakes` link to `wiki.nixos.org`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de3cabbe5c07516b3e0254e8b9ec48659d83739f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->