### PR TITLE
Move uv lock check from CI to pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
-      - name: Check uv.lock is up to date
-        run: uv lock --locked
-        env:
-          UV_PYTHON: ${{ matrix.python-version }}
-
       - name: Lint
         run: |
           uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ ci:
     - ty-docs
     - pyrefly
     - pyrefly-docs
+    - uv-lock
     - vulture
     - vulture-docs
     - yamlfix
@@ -409,5 +410,14 @@ repos:
           --ignore=docs/build
         language: python
         types_or: [rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: uv-lock
+        name: uv lock
+        entry: uv lock --locked
+        language: python
+        pass_filenames: false
+        files: (^pyproject\.toml$|^uv\.lock$)
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]


### PR DESCRIPTION
Move the `uv lock --locked` check from the GitHub Actions CI workflow to a pre-commit hook.

Changes:
- Add new `uv-lock` pre-commit hook that runs on changes to `pyproject.toml` or `uv.lock`
- Add `uv-lock` to the CI skip list (since pre-commit.ci uses system Python)
- Remove the dedicated "Check uv.lock is up to date" step from the CI workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the `uv lock --locked` check from GitHub Actions to pre-commit.
> 
> - Removes the dedicated `uv lock --locked` step from `/.github/workflows/ci.yml`
> - Adds a `uv-lock` pre-commit hook that runs on changes to `pyproject.toml` or `uv.lock`
> - Skips `uv-lock` in `pre-commit.ci` via `.pre-commit-config.yaml` `ci.skip`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cebb58e0287fd9f0b5c6b9592245904a0cf1722f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->