### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       id-token: write
       # This is needed for https://github.com/stefanzweifel/git-auto-commit-action.
       contents: write
+      # This is needed for pushing Docker images to ghcr.io.
+      packages: write
 
     steps:
       - uses: actions/checkout@v6
@@ -259,3 +261,25 @@ jobs:
           makeLatest: true
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            DOCCMD_VERSION=${{ steps.calver.outputs.release }}
+          tags: |-
+            ghcr.io/adamtheturtle/doccmd:${{ steps.calver.outputs.release }}
+            ghcr.io/adamtheturtle/doccmd:latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ ci:
   # We therefore cannot use those dependencies in pre-commit CI.
   skip:
     - actionlint
+    - hadolint
     - check-manifest
     - deptry
     - doc8
@@ -109,6 +110,14 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: hadolint
+        name: hadolint
+        entry: uv run --extra=dev hadolint
+        language: python
+        files: Dockerfile
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.13-slim
+
+LABEL org.opencontainers.image.source="https://github.com/adamtheturtle/doccmd"
+LABEL org.opencontainers.image.description="Run commands against code blocks in documentation"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ARG DOCCMD_VERSION
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Install the package from PyPI with pinned version
+RUN uv pip install --system --no-cache "doccmd==${DOCCMD_VERSION}"
+
+ENTRYPOINT ["doccmd"]

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,13 @@ Pre-built Linux (x86) binaries
    $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2026.01.22/doccmd-linux -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+With Docker
+~~~~~~~~~~~
+
+.. code-block:: console
+
+   $ docker run --rm -v "$(pwd):/workdir" -w /workdir "ghcr.io/adamtheturtle/doccmd" --help
+
 With Nix
 ^^^^^^^^
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,4 +116,5 @@ rst_prolog = f"""
 .. |minimum-python-version| replace:: {minimum_python_version}
 .. |github-owner| replace:: adamtheturtle
 .. |github-repository| replace:: doccmd
+.. |docker-image| replace:: ghcr.io/adamtheturtle/doccmd
 """

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,6 +31,14 @@ Pre-built Linux (x86) binaries
    $ curl --fail -L "https://github.com/|github-owner|/|github-repository|/releases/download/|release|/doccmd-linux" -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+With Docker
+~~~~~~~~~~~
+
+.. code-block:: console
+   :substitutions:
+
+   $ docker run --rm -v "$(pwd):/workdir" -w /workdir "|docker-image|" --help
+
 With Nix
 ~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ optional-dependencies.dev = [
     "doc8==2.0.0",
     "docformatter==1.7.7",
     "furo==2025.12.19",
+    # hadolint is not available on Windows.
+    "hadolint-bin==2.14.0; sys_platform!='win32'",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",
@@ -300,6 +302,7 @@ make-summary-multi-line = true
 
 ignore = [
     ".checkmake-config.ini",
+    "Dockerfile",
     ".prettierrc",
     ".yamlfmt",
     "*.enc",

--- a/uv.lock
+++ b/uv.lock
@@ -487,6 +487,7 @@ dev = [
     { name = "doc8" },
     { name = "docformatter" },
     { name = "furo" },
+    { name = "hadolint-bin", marker = "sys_platform != 'win32'" },
     { name = "interrogate" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "mypy-strict-kwargs" },
@@ -542,6 +543,7 @@ requires-dist = [
     { name = "doc8", marker = "extra == 'dev'", specifier = "==2.0.0" },
     { name = "docformatter", marker = "extra == 'dev'", specifier = "==1.7.7" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
+    { name = "hadolint-bin", marker = "sys_platform != 'win32' and extra == 'dev'", specifier = "==2.14.0" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -657,6 +659,17 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
+]
+
+[[package]]
+name = "hadolint-bin"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/e9/e0bd73b241d672d3ce6b95d5afd711b7190262146007f426fceb313851b4/hadolint_bin-2.14.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:25c57c9c0f287c580179de5c9279165b8bf5190a302b354baf277d067aed074f", size = 4728151, upload-time = "2025-10-12T03:02:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/58/02b3cd41b29b37d406988267dae0a548b1123ee2744971f8a776a573258e/hadolint_bin-2.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ea4a07c134b8047ad88561318b61606b57c7ee4fe5e07c6fed344e96b782d6f5", size = 20990522, upload-time = "2025-10-12T03:02:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0c/16cd3266516966ad93b670709b84968d56c0cf87be8648d64fff1d353fbf/hadolint_bin-2.14.0-py3-none-manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b257fa0773636e7a4c52c5b8861b7f0a57725ce3c748d4879557f4b8a08178c8", size = 12841415, upload-time = "2025-10-12T03:02:20.646Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b6/c383d0a95dbf110c20a4c050accce88b747dbe36759dc2ceb76fb2c5fc3f/hadolint_bin-2.14.0-py3-none-manylinux2014_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:cc65ee5fb9c700dc246a54c8fc5434bb3092da40c194e6561fde8ed0e6a77941", size = 11940448, upload-time = "2025-10-12T03:02:22.59Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add Docker containerization support:

- Add Dockerfile using python:3.13-slim base image with uv for package installation
- Add Docker build/push steps to release workflow (multi-platform: linux/amd64, linux/arm64)
- Add hadolint for Dockerfile linting (dev dependency + pre-commit hook)
- Add Docker installation instructions to README and docs

Docker images will be published to `ghcr.io/adamtheturtle/doccmd` on release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces containerized distribution and integrates it into releases.
> 
> - **Dockerfile**: New image based on `python:3.13-slim`, installs via `uv`, `ARG DOCCMD_VERSION`, `ENTRYPOINT` to `doccmd`
> - **Release workflow**: Adds `packages: write` permission and Buildx/login steps; builds and pushes multi-arch (`linux/amd64`, `linux/arm64`) images to `ghcr.io/adamtheturtle/doccmd` with `latest` and `|release|` tags using build-arg `DOCCMD_VERSION`
> - **Tooling**: Adds `hadolint` (dev dep `hadolint-bin`, pre-commit hook; skipped in CI); updates `check-manifest` ignore and `uv.lock`
> - **Docs**: README and Sphinx install docs updated with Docker usage and `|docker-image|` substitution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7490347517a1f477b1b061553b0e8f7fbd52c17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->