### PR TITLE
Fix heading levels for installation options in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Requires `Homebrew`_.
 .. _Homebrew: https://docs.brew.sh/Installation
 
 Pre-built Linux (x86) binaries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -42,7 +42,7 @@ Pre-built Linux (x86) binaries
        chmod +x /usr/local/bin/doccmd
 
 With Docker
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 .. code-block:: console
 


### PR DESCRIPTION
The 'Pre-built Linux (x86) binaries' and 'With Docker' sections were using level 4 headings (`~~~~`) while all other installation options used level 3 headings (`^^^^`). This fixes them to be consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns installation section heading levels in `README.rst` for consistency.
> 
> - Changes `Pre-built Linux (x86) binaries` and `With Docker` headings from level-4 (`~~~~`) to level-3 (`^^^^`) to match other installation sections
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74b9389854f72e5e9c734589481696f8b6adb6b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->