### PR TITLE
Fix Windows binary build by creating requirements.txt separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,14 +314,16 @@ jobs:
             normalized_version=$(echo "${{ needs.build.outputs.new_tag }}" | sed -E 's/\.0+([0-9])/.\1/g')
             pip index versions doccmd | grep -wq "$normalized_version"
 
+      - name: Create requirements file
+        run: echo "doccmd==${{ needs.build.outputs.new_tag }}" > requirements.txt
+
       - name: Create Windows binary
         uses: sayyid5416/pyinstaller@v1
         with:
           python_ver: '3.13'
           pyinstaller_ver: ==6.12.0
           spec: bin/doccmd-wrapper.py
-          requirements: '`echo doccmd==${{ needs.build.outputs.new_tag }} > requirements.txt
-            && echo requirements.txt`'
+          requirements: requirements.txt
           options: --onefile, --name "doccmd-windows"
           upload_exe_with_name: doccmd-windows
           clean_checkout: false


### PR DESCRIPTION
## Problem

The backtick workaround used for Linux to create requirements.txt on-the-fly doesn't work on Windows. The PyInstaller action was treating the requirement string as a file path.

## Solution

Create the requirements.txt file in a separate step before running the PyInstaller action.

## Error fixed

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'doccmd==2026.01.23'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Windows packaging in the release workflow by avoiding inline requirements creation.
> 
> - Add a dedicated step to write `requirements.txt` with `doccmd==${{ needs.build.outputs.new_tag }}`
> - Update PyInstaller `requirements` input to use `requirements.txt` instead of the inline backtick command (which failed on Windows)
> 
> Prevents the "Could not open requirements file" error during the Windows build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcbc380ffa311a18b1ccf5d9a0f8896cfc29ceaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->