### PR TITLE
Disable winget publishing until package is registered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,23 +334,25 @@ jobs:
         run: |
           gh release upload ${{ needs.build.outputs.new_tag }} dist/doccmd-windows.exe --clobber
 
-  publish-winget:
-    name: Publish to winget
-    needs: [build, build-windows]
-    runs-on: windows-latest
-
-    permissions:
-      contents: read
-
-    steps:
-      # The winget-releaser action requires the package to already exist in
-      # the winget-pkgs repository. For the first release, you need to manually
-      # submit the package to https://github.com/microsoft/winget-pkgs.
-      # After that, this action will automatically update the package.
-      - name: Publish to winget
-        uses: vedantmgoyal9/winget-releaser@v2
-        with:
-          identifier: adamtheturtle.doccmd
-          installers-regex: \.exe$
-          release-tag: ${{ needs.build.outputs.new_tag }}
-          token: ${{ secrets.WINGET_TOKEN }}
+  # TODO: Uncomment once adamtheturtle.doccmd is registered in winget-pkgs.
+  # See https://github.com/microsoft/winget-pkgs for manual submission.
+  # publish-winget:
+  #   name: Publish to winget
+  #   needs: [build, build-windows]
+  #   runs-on: windows-latest
+  #
+  #   permissions:
+  #     contents: read
+  #
+  #   steps:
+  #  # The winget-releaser action requires the package to already exist in
+  #  # the winget-pkgs repository. For the first release, you need to manually
+  #  # submit the package to https://github.com/microsoft/winget-pkgs.
+  #  # After that, this action will automatically update the package.
+  #     - name: Publish to winget
+  #       uses: vedantmgoyal9/winget-releaser@v2
+  #       with:
+  #         identifier: adamtheturtle.doccmd
+  #         installers-regex: \.exe$
+  #         release-tag: ${{ needs.build.outputs.new_tag }}
+  #         token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
The winget-releaser action requires the package to already exist in the winget-pkgs repository.

This comments out the publish-winget job until we manually submit the package to https://github.com/microsoft/winget-pkgs.

Once the initial package is registered, uncomment the job and future releases will auto-update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables Winget publishing in the release workflow until the package is registered in `winget-pkgs`.
> 
> - Removes the active `publish-winget` job and replaces it with a commented TODO block with manual submission instructions
> - Keeps Windows binary build/upload intact; no changes to build or release steps beyond Winget
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb0e4ad19bd9986c45f0cd108c2c4a03ff22f7e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->