### PR TITLE
Document pre-built Windows binary installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,13 @@ Pre-built Linux (x86) binaries
    $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2026.01.23.2/doccmd-linux -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+Pre-built Windows binaries
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Download the Windows executable from the `latest release`_ and place it in a directory on your ``PATH``.
+
+.. _latest release: https://github.com/adamtheturtle/doccmd/releases/latest
+
 With Docker
 ^^^^^^^^^^^
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -42,6 +42,13 @@ Pre-built Linux (x86) binaries
    $ curl --fail -L "https://github.com/|github-owner|/|github-repository|/releases/download/|release|/doccmd-linux" -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+Pre-built Windows binaries
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Download the Windows executable from the `latest release`_ and place it in a directory on your ``PATH``.
+
+.. _latest release: https://github.com/adamtheturtle/doccmd/releases/latest
+
 With Docker
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Adds installation instructions for the pre-built Windows binary to both README.rst and docs/source/install.rst.

Users can download `doccmd-windows.exe` from the latest release and add it to their PATH.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Windows pre-built binary installation instructions to the docs.
> 
> - New "Pre-built Windows binaries" sections in `README.rst` and `docs/source/install.rst`
> - Directs users to download `doccmd-windows.exe` from the `latest release` and add it to `PATH`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3445c9a44b0f05caf6289560315d622def08c45b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->