### PR TITLE
Comment out winget installation docs until package is registered

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,16 +33,20 @@ Requires `Homebrew`_.
 
 .. _Homebrew: https://docs.brew.sh/Installation
 
-With winget (Windows)
-^^^^^^^^^^^^^^^^^^^^^
+..
+   TODO: Uncomment once adamtheturtle.doccmd is registered in winget-pkgs.
+   See https://github.com/adamtheturtle/doccmd/issues/727
 
-Requires `winget`_.
+   With winget (Windows)
+   ^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: shell
+   Requires `winget`_.
 
-   $ winget install adamtheturtle.doccmd
+   .. code-block:: shell
 
-.. _winget: https://learn.microsoft.com/en-us/windows/package-manager/winget/
+      $ winget install adamtheturtle.doccmd
+
+   .. _winget: https://learn.microsoft.com/en-us/windows/package-manager/winget/
 
 Pre-built Linux (x86) binaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,16 +22,20 @@ Requires `Homebrew`_.
 
 .. _Homebrew: https://docs.brew.sh/Installation
 
-With winget (Windows)
-~~~~~~~~~~~~~~~~~~~~~
+..
+   TODO: Uncomment once adamtheturtle.doccmd is registered in winget-pkgs.
+   See https://github.com/adamtheturtle/doccmd/issues/727
 
-Requires `winget`_.
+   With winget (Windows)
+   ~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: console
+   Requires `winget`_.
 
-   $ winget install adamtheturtle.doccmd
+   .. code-block:: console
 
-.. _winget: https://learn.microsoft.com/en-us/windows/package-manager/winget/
+      $ winget install adamtheturtle.doccmd
+
+   .. _winget: https://learn.microsoft.com/en-us/windows/package-manager/winget/
 
 Pre-built Linux (x86) binaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The winget installation instructions are commented out until the package is manually submitted to winget-pkgs.

See #727 for the steps to register the package. Once registered, uncomment the docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily hides Windows `winget` installation instructions and refreshes a Linux download link.
> 
> - Comment out the `winget` installation section in `README.rst` and `docs/source/install.rst`, adding a TODO with reference to issue `#727`
> - Update `README.rst` pre-built Linux (x86) binary URL to release `2026.01.23.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ed5886dc1ed2ae26b3ecd505ee44ceb317004d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->