### PR TITLE
Add note about removing quarantine attribute for macOS binary

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,12 @@ Pre-built macOS (ARM) binaries
    $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2026.01.23.4/doccmd-macos -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+You may need to remove the quarantine attribute to run the binary:
+
+.. code-block:: console
+
+   $ xattr -d com.apple.quarantine /usr/local/bin/doccmd
+
 Pre-built Windows binaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -55,6 +55,12 @@ Pre-built macOS (ARM) binaries
    $ curl --fail -L "https://github.com/|github-owner|/|github-repository|/releases/download/|release|/doccmd-macos" -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
+You may need to remove the quarantine attribute to run the binary:
+
+.. code-block:: console
+
+   $ xattr -d com.apple.quarantine /usr/local/bin/doccmd
+
 Pre-built Windows binaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
When downloading the macOS binary, macOS Gatekeeper blocks unsigned binaries. This adds a note explaining that users may need to run `xattr -d com.apple.quarantine /usr/local/bin/doccmd` to remove the quarantine attribute before the binary will execute.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies macOS installation by documenting the quarantine removal step required for unsigned binaries.
> 
> - Adds note and command to remove quarantine (`xattr -d com.apple.quarantine /usr/local/bin/doccmd`) in `README.rst` and `docs/source/install.rst`
> - Updates README with an additional macOS (ARM) install snippet referencing a specific release URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb7b214edfcb204e5de746767b3ac8477431bebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->