### PR TITLE
Replace docformatter with pydocstringformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ ci:
     - check-manifest
     - deptry
     - doc8
-    - docformatter
+    - pydocstringformatter
     - docs
     - interrogate
     - interrogate-docs
@@ -121,9 +121,9 @@ repos:
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
 
-      - id: docformatter
-        name: docformatter
-        entry: uv run --extra=dev -m docformatter --in-place
+      - id: pydocstringformatter
+        name: pydocstringformatter
+        entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
         additional_dependencies: [uv==0.9.5]

--- a/bin/doccmd-wrapper.py
+++ b/bin/doccmd-wrapper.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""
-Run doccmd.
-"""
+"""Run doccmd."""
 
 from doccmd import main
 

--- a/docs/source/__init__.py
+++ b/docs/source/__init__.py
@@ -1,3 +1,1 @@
-"""
-Documentation for `doccmd`.
-"""
+"""Documentation for `doccmd`."""

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,4 @@
-"""
-Configuration for Sphinx.
-"""
+"""Configuration for Sphinx."""
 
 # pylint: disable=invalid-name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,14 @@ lint.ignore = [
     "PLR0915",
 ]
 
+lint.per-file-ignores."doccmd_*.py" = [
+    # Allow our chosen docstring line-style - pydocstringformatter handles
+    # formatting but docstrings in docs may not match this style.
+    "D200",
+    # Allow asserts in docs.
+    "S101",
+]
+
 lint.per-file-ignores."tests/*.py" = [
     # Do not require tests to have a one-line summary.
     "S101",

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -1,6 +1,4 @@
-"""
-CLI to run commands on the given files.
-"""
+"""CLI to run commands on the given files."""
 
 import difflib
 import os
@@ -61,9 +59,7 @@ T = TypeVar("T")
 
 @beartype
 class _LogCommandEvaluator:
-    """
-    Log a command before running it.
-    """
+    """Log a command before running it."""
 
     def __init__(
         self,
@@ -78,9 +74,7 @@ class _LogCommandEvaluator:
         self._args = args
 
     def __call__(self, example: Example) -> None:
-        """
-        Log the command before running it.
-        """
+        """Log the command before running it."""
         command_str = shlex.join(
             split_command=[str(object=item) for item in self._args],
         )
@@ -97,9 +91,7 @@ def _validate_file_extension(
     param: click.Parameter | None,
     value: str,
 ) -> str:
-    """
-    Validate that the input string starts with a dot.
-    """
+    """Validate that the input string starts with a dot."""
     if not value.startswith("."):
         message = f"'{value}' does not start with a '.'."
         raise click.BadParameter(message=message, ctx=ctx, param=param)
@@ -112,9 +104,7 @@ def _validate_file_extension_or_none(
     param: click.Parameter | None,
     value: str | None,
 ) -> str | None:
-    """
-    Validate that the input string starts with a dot.
-    """
+    """Validate that the input string starts with a dot."""
     if value is None:
         return value
     return _validate_file_extension(ctx=ctx, param=param, value=value)
@@ -126,9 +116,7 @@ def _validate_given_files_have_known_suffixes(
     given_files: Iterable[Path],
     known_suffixes: Iterable[str],
 ) -> None:
-    """
-    Validate that the given files have known suffixes.
-    """
+    """Validate that the given files have known suffixes."""
     given_files_unknown_suffix = [
         document_path
         for document_path in given_files
@@ -146,9 +134,7 @@ def _validate_no_empty_string(
     param: click.Parameter | None,
     value: str,
 ) -> str:
-    """
-    Validate that the input strings are not empty.
-    """
+    """Validate that the input strings are not empty."""
     if not value:
         msg = "This value cannot be empty."
         raise click.BadParameter(message=msg, ctx=ctx, param=param)
@@ -175,7 +161,8 @@ def _get_file_paths(
     exclude_patterns: Iterable[str],
 ) -> Sequence[Path]:
     """
-    Get the file paths from the given document paths (files and directories).
+    Get the file paths from the given document paths (files and
+    directories).
     """
     file_paths: dict[Path, bool] = {}
     for path in document_paths:
@@ -202,9 +189,7 @@ def _validate_file_suffix_overlaps(
     *,
     suffix_groups: Mapping[MarkupLanguage, Iterable[str]],
 ) -> None:
-    """
-    Validate that the given file suffixes do not overlap.
-    """
+    """Validate that the given file suffixes do not overlap."""
     for markup_language, suffixes in suffix_groups.items():
         for other_markup_language, other_suffixes in suffix_groups.items():
             if markup_language is other_markup_language:
@@ -225,9 +210,7 @@ def _validate_file_suffix_overlaps(
 
 @unique
 class _UsePty(Enum):
-    """
-    Choices for the use of a pseudo-terminal.
-    """
+    """Choices for the use of a pseudo-terminal."""
 
     YES = auto()
     NO = auto()
@@ -250,9 +233,7 @@ class _UsePty(Enum):
         return self.name.lower()
 
     def use_pty(self) -> bool:
-        """
-        Whether to use a pseudo-terminal.
-        """
+        """Whether to use a pseudo-terminal."""
         if self is _UsePty.DETECT:
             return sys.stdout.isatty() and platform.system() != "Windows"
         return {
@@ -263,36 +244,28 @@ class _UsePty(Enum):
 
 @beartype
 def _log_info(message: str) -> None:
-    """
-    Log an info message.
-    """
+    """Log an info message."""
     styled_message = click.style(text=message, fg="green")
     click.echo(message=styled_message, err=True)
 
 
 @beartype
 def _log_warning(message: str) -> None:
-    """
-    Log an error message.
-    """
+    """Log an error message."""
     styled_message = click.style(text=message, fg="yellow")
     click.echo(message=styled_message, err=True)
 
 
 @beartype
 def _log_error(message: str) -> None:
-    """
-    Log an error message.
-    """
+    """Log an error message."""
     styled_message = click.style(text=message, fg="red")
     click.echo(message=styled_message, err=True)
 
 
 @beartype
 def _detect_newline(content_bytes: bytes) -> bytes | None:
-    """
-    Detect the newline character used in the content.
-    """
+    """Detect the newline character used in the content."""
     for newline in (b"\r\n", b"\n", b"\r"):
         if newline in content_bytes:
             return newline
@@ -301,9 +274,7 @@ def _detect_newline(content_bytes: bytes) -> bytes | None:
 
 @beartype
 def _map_languages_to_suffix() -> dict[str, str]:
-    """
-    Map programming languages to their corresponding file extension.
-    """
+    """Map programming languages to their corresponding file extension."""
     language_extension_map: dict[str, str] = {}
 
     for lexer in get_all_lexers():
@@ -322,9 +293,7 @@ def _map_languages_to_suffix() -> dict[str, str]:
 
 @beartype
 def _get_group_directives(markers: Iterable[str]) -> Sequence[str]:
-    """
-    Group directives based on the provided markers.
-    """
+    """Group directives based on the provided markers."""
     directives: Sequence[str] = []
 
     for marker in markers:
@@ -335,9 +304,7 @@ def _get_group_directives(markers: Iterable[str]) -> Sequence[str]:
 
 @beartype
 def _get_skip_directives(markers: Iterable[str]) -> Iterable[str]:
-    """
-    Skip directives based on the provided markers.
-    """
+    """Skip directives based on the provided markers."""
     directives: Sequence[str] = []
 
     for marker in markers:
@@ -351,9 +318,7 @@ def _get_temporary_file_extension(
     language: str,
     given_file_extension: str | None,
 ) -> str:
-    """
-    Get the file suffix, either from input or based on the language.
-    """
+    """Get the file suffix, either from input or based on the language."""
     if given_file_extension is None:
         language_to_suffix = _map_languages_to_suffix()
         given_file_extension = language_to_suffix.get(language.lower(), ".txt")
@@ -363,9 +328,7 @@ def _get_temporary_file_extension(
 
 @beartype
 def _resolve_workers(*, requested_workers: int) -> int:
-    """
-    Resolve the input worker count, auto-detecting CPUs when zero.
-    """
+    """Resolve the input worker count, auto-detecting CPUs when zero."""
     if requested_workers != 0:
         return requested_workers
 
@@ -381,9 +344,7 @@ def _evaluate_document(
     document: Document,
     example_workers: int,
 ) -> None:
-    """
-    Evaluate the document.
-    """
+    """Evaluate the document."""
     examples = tuple(document.examples())
     if example_workers == 1 or len(examples) in {0, 1}:
         for example in examples:
@@ -400,7 +361,8 @@ def _evaluate_document(
 @beartype
 class _GroupModifiedError(Exception):
     """
-    Error raised when there was an attempt to modify a code block in a group.
+    Error raised when there was an attempt to modify a code block in a
+    group.
     """
 
     def __init__(
@@ -409,16 +371,12 @@ class _GroupModifiedError(Exception):
         example: Example,
         modified_example_content: str,
     ) -> None:
-        """
-        Initialize the error.
-        """
+        """Initialize the error."""
         self._example = example
         self._modified_example_content = modified_example_content
 
     def __str__(self) -> str:
-        """
-        Get the string representation of the error.
-        """
+        """Get the string representation of the error."""
         unified_diff = difflib.unified_diff(
             a=str(object=self._example.parsed).lstrip().splitlines(),
             b=self._modified_example_content.lstrip().splitlines(),
@@ -442,9 +400,7 @@ class _GroupModifiedError(Exception):
 
 @dataclass
 class _CollectedError:
-    """
-    Error collected during continue-on-error mode.
-    """
+    """Error collected during continue-on-error mode."""
 
     message: str
     exit_code: int
@@ -452,13 +408,12 @@ class _CollectedError:
 
 class _FatalProcessingError(Exception):
     """
-    Error raised when processing a document requires exiting immediately.
+    Error raised when processing a document requires exiting
+    immediately.
     """
 
     def __init__(self, exit_code: int) -> None:
-        """
-        Capture the exit code doccmd should terminate with.
-        """
+        """Capture the exit code doccmd should terminate with."""
         self.exit_code = exit_code
         super().__init__()
 
@@ -471,9 +426,7 @@ def _handle_error(
     continue_on_error: bool,
     exc: Exception | None = None,
 ) -> _CollectedError:
-    """
-    Handle an error by either returning it or raising a fatal error.
-    """
+    """Handle an error by either returning it or raising a fatal error."""
     if continue_on_error:
         return _CollectedError(message=message, exit_code=exit_code)
     raise _FatalProcessingError(exit_code=exit_code) from exc
@@ -503,9 +456,7 @@ def _process_file_path(
     continue_on_error: bool,
     example_workers: int,
 ) -> list[_CollectedError]:
-    """
-    Process a single documentation file.
-    """
+    """Process a single documentation file."""
     local_errors: list[_CollectedError] = []
     markup_language = suffix_map[file_path.suffix]
     encoding = _get_encoding(document_path=file_path)
@@ -658,7 +609,8 @@ def _raise_group_modified(
     modified_example_content: str,
 ) -> None:
     """
-    Raise an error when there was an attempt to modify a code block in a group.
+    Raise an error when there was an attempt to modify a code block in a
+    group.
     """
     raise _GroupModifiedError(
         example=example,
@@ -668,9 +620,7 @@ def _raise_group_modified(
 
 @beartype
 def _get_encoding(*, document_path: Path) -> str | None:
-    """
-    Get the encoding of the file.
-    """
+    """Get the encoding of the file."""
     content_bytes = document_path.read_bytes()
     charset_matches = charset_normalizer.from_bytes(sequences=content_bytes)
     best_match = charset_matches.best()
@@ -700,9 +650,7 @@ def _get_sybil(
     newline: str | None,
     parse_sphinx_jinja2: bool,
 ) -> Sybil:
-    """
-    Get a Sybil for running commands on the given file.
-    """
+    """Get a Sybil for running commands on the given file."""
     # Add default "all" marker if:
     # - Not using group_file
     # - AND (not using group_mdx_by_attribute OR this is not an MDX file)

--- a/src/doccmd/__main__.py
+++ b/src/doccmd/__main__.py
@@ -1,6 +1,4 @@
-"""
-Enable running `doccmd` with `python -m doccmd`.
-"""
+"""Enable running `doccmd` with `python -m doccmd`."""
 
 from doccmd import main
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for `doccmd`.
-"""
+"""Tests for `doccmd`."""

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1,6 +1,4 @@
-"""
-Tests for `doccmd`.
-"""
+"""Tests for `doccmd`."""
 
 import os
 import stat
@@ -43,7 +41,8 @@ def test_help(file_regression: FileRegressionFixture) -> None:
 
 def test_run_command(tmp_path: Path) -> None:
     """
-    It is possible to run a command against a code block in a document.
+    It is possible to run a command against a code block in a
+    document.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -86,9 +85,7 @@ def test_run_command(tmp_path: Path) -> None:
 
 
 def test_double_language(tmp_path: Path) -> None:
-    """
-    Giving the same language twice does not run the command twice.
-    """
+    """Giving the same language twice does not run the command twice."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -132,9 +129,7 @@ def test_double_language(tmp_path: Path) -> None:
 
 
 def test_file_does_not_exist() -> None:
-    """
-    An error is shown when a file does not exist.
-    """
+    """An error is shown when a file does not exist."""
     runner = CliRunner()
     arguments = [
         "--language",
@@ -154,9 +149,7 @@ def test_file_does_not_exist() -> None:
 
 
 def test_not_utf_8_file_given(tmp_path: Path) -> None:
-    """
-    No error is given if a file is passed in which is not UTF-8.
-    """
+    """No error is given if a file is passed in which is not UTF-8."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -199,9 +192,7 @@ def test_unknown_encoding(
     fail_on_parse_error_options: Sequence[str],
     expected_exit_code: int,
 ) -> None:
-    """
-    An error is shown when a file cannot be decoded.
-    """
+    """An error is shown when a file cannot be decoded."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     rst_file.write_bytes(data=Path(sys.executable).read_bytes())
@@ -229,7 +220,8 @@ def test_unknown_encoding(
 
 def test_multiple_code_blocks(tmp_path: Path) -> None:
     """
-    It is possible to run a command against multiple code blocks in a document.
+    It is possible to run a command against multiple code blocks in a
+    document.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -284,9 +276,7 @@ def test_multiple_code_blocks(tmp_path: Path) -> None:
 
 
 def test_language_filters(tmp_path: Path) -> None:
-    """
-    Languages not specified are not run.
-    """
+    """Languages not specified are not run."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -331,9 +321,7 @@ def test_language_filters(tmp_path: Path) -> None:
 
 
 def test_run_command_no_pad_file(tmp_path: Path) -> None:
-    """
-    It is possible to not pad the file.
-    """
+    """It is possible to not pad the file."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -372,9 +360,7 @@ def test_run_command_no_pad_file(tmp_path: Path) -> None:
 
 
 def test_multiple_files(tmp_path: Path) -> None:
-    """
-    It is possible to run a command against multiple files.
-    """
+    """It is possible to run a command against multiple files."""
     runner = CliRunner()
     rst_file1 = tmp_path / "example1.rst"
     rst_file2 = tmp_path / "example2.rst"
@@ -426,7 +412,8 @@ def test_multiple_files(tmp_path: Path) -> None:
 
 def test_multiple_files_multiple_types(tmp_path: Path) -> None:
     """
-    It is possible to run a command against multiple files of multiple types
+    It is possible to run a command against multiple files of multiple
+    types
     (Markdown and rST).
     """
     runner = CliRunner()
@@ -527,9 +514,7 @@ def test_modify_file(
     write_to_file_options: Sequence[str],
     expected_content: str,
 ) -> None:
-    """
-    Commands (outside of groups) can modify files when allowed.
-    """
+    """Commands (outside of groups) can modify files when allowed."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -573,9 +558,7 @@ def test_modify_file(
 
 
 def test_exit_code(tmp_path: Path) -> None:
-    """
-    The exit code of the first failure is propagated.
-    """
+    """The exit code of the first failure is propagated."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     exit_code = 25
@@ -619,7 +602,8 @@ def test_file_extension(
     expected_extension: str,
 ) -> None:
     """
-    The file extension of the temporary file is appropriate for the language.
+    The file extension of the temporary file is appropriate for the
+    language.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -653,7 +637,8 @@ def test_file_extension(
 
 def test_given_temporary_file_extension(tmp_path: Path) -> None:
     """
-    It is possible to specify the file extension for created temporary files.
+    It is possible to specify the file extension for created temporary
+    files.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -691,7 +676,8 @@ def test_given_temporary_file_extension_no_leading_period(
     tmp_path: Path,
 ) -> None:
     """
-    An error is shown when a given temporary file extension is given with no
+    An error is shown when a given temporary file extension is given
+    with no
     leading period.
     """
     runner = CliRunner()
@@ -734,9 +720,7 @@ def test_given_temporary_file_extension_no_leading_period(
 
 
 def test_given_prefix(tmp_path: Path) -> None:
-    """
-    It is possible to specify a prefix for the temporary file.
-    """
+    """It is possible to specify a prefix for the temporary file."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -805,9 +789,7 @@ def test_file_extension_unknown_language(tmp_path: Path) -> None:
 
 
 def test_file_given_multiple_times(tmp_path: Path) -> None:
-    """
-    Files given multiple times are de-duplicated.
-    """
+    """Files given multiple times are de-duplicated."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     other_rst_file = tmp_path / "other_example.rst"
@@ -866,9 +848,7 @@ def test_workers_requires_no_write_to_file(
     tmp_path: Path,
     worker_flag: str,
 ) -> None:
-    """
-    Using workers>1 without --no-write-to-file is rejected.
-    """
+    """Using workers>1 without --no-write-to-file is rejected."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -905,7 +885,8 @@ def test_workers_runs_commands(
     worker_flag: str,
 ) -> None:
     """
-    Commands run successfully when workers>1 and --no-write-to-file is given.
+    Commands run successfully when workers>1 and --no-write-to-file is
+    given.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -951,7 +932,8 @@ def test_workers_zero_requires_no_write_when_auto_parallel(
     worker_flag: str,
 ) -> None:
     """
-    Workers=0 auto-detects CPUs and still requires --no-write-to-file when >1.
+    Workers=0 auto-detects CPUs and still requires --no-write-to-file
+    when >1.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -991,7 +973,8 @@ def test_workers_zero_allows_running_when_cpu_is_single(
     worker_flag: str,
 ) -> None:
     """
-    Workers=0 falls back to sequential execution when only one CPU is detected.
+    Workers=0 falls back to sequential execution when only one CPU is
+    detected.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -1025,9 +1008,7 @@ def test_cpu_count_returns_none(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """
-    When os.cpu_count() returns None, workers default to 1.
-    """
+    """When os.cpu_count() returns None, workers default to 1."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1064,9 +1045,7 @@ def test_parallel_execution_error(
     tmp_path: Path,
     worker_flag: str,
 ) -> None:
-    """
-    Errors during parallel execution are handled correctly.
-    """
+    """Errors during parallel execution are handled correctly."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1106,9 +1085,7 @@ def test_parallel_execution_error(
 
 
 def test_document_with_no_examples(tmp_path: Path) -> None:
-    """
-    Documents with no matching code blocks are handled correctly.
-    """
+    """Documents with no matching code blocks are handled correctly."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1159,9 +1136,7 @@ def test_execution_error_handling(
     worker_options: list[str],
     num_blocks: int,
 ) -> None:
-    """
-    Errors are handled correctly across different execution modes.
-    """
+    """Errors are handled correctly across different execution modes."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
 
@@ -1211,7 +1186,8 @@ def test_single_example_with_parallel_workers(
     expected_stderr: str,
 ) -> None:
     """
-    Single example with example_workers>1 falls back to sequential execution.
+    Single example with example_workers>1 falls back to sequential
+    execution.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -1246,9 +1222,7 @@ def test_single_example_with_parallel_workers(
 
 
 def test_verbose_running(tmp_path: Path) -> None:
-    """
-    ``--verbose`` shows what is running.
-    """
+    """``--verbose`` shows what is running."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1305,9 +1279,7 @@ def test_verbose_running(tmp_path: Path) -> None:
 
 
 def test_verbose_running_with_stderr(tmp_path: Path) -> None:
-    """
-    ``--verbose`` shows what is running before any stderr output.
-    """
+    """``--verbose`` shows what is running before any stderr output."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     # We include a group as well to ensure that the verbose output is shown
@@ -1374,9 +1346,7 @@ def test_verbose_running_with_stderr(tmp_path: Path) -> None:
 
 
 def test_main_entry_point() -> None:
-    """
-    It is possible to run the main entry point.
-    """
+    """It is possible to run the main entry point."""
     result = subprocess.run(
         args=[sys.executable, "-m", "doccmd"],
         capture_output=True,
@@ -1387,9 +1357,7 @@ def test_main_entry_point() -> None:
 
 
 def test_command_not_found(tmp_path: Path) -> None:
-    """
-    An error is shown when the command is not found.
-    """
+    """An error is shown when the command is not found."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     non_existent_command = uuid.uuid4().hex
@@ -1425,9 +1393,7 @@ def test_command_not_found(tmp_path: Path) -> None:
 
 
 def test_not_executable(tmp_path: Path) -> None:
-    """
-    An error is shown when the command is a non-executable file.
-    """
+    """An error is shown when the command is a non-executable file."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     not_executable_command = tmp_path / "non_executable"
@@ -1466,7 +1432,8 @@ def test_not_executable(tmp_path: Path) -> None:
 
 def test_multiple_languages(tmp_path: Path) -> None:
     """
-    It is possible to run a command against multiple code blocks in a document
+    It is possible to run a command against multiple code blocks in a
+    document
     with different languages.
     """
     runner = CliRunner()
@@ -1517,7 +1484,8 @@ def test_multiple_languages(tmp_path: Path) -> None:
 
 def test_default_skip_rst(tmp_path: Path) -> None:
     """
-    By default, the next code block after a 'skip doccmd: next' comment in a
+    By default, the next code block after a 'skip doccmd: next' comment
+    in a
     rST document is not run.
     """
     runner = CliRunner()
@@ -1578,9 +1546,7 @@ def test_skip_no_arguments(
     fail_on_parse_error_options: Sequence[str],
     expected_exit_code: int,
 ) -> None:
-    """
-    An error is shown if a skip is given with no arguments.
-    """
+    """An error is shown if a skip is given with no arguments."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1634,9 +1600,7 @@ def test_skip_bad_arguments(
     fail_on_parse_error_options: Sequence[str],
     expected_exit_code: int,
 ) -> None:
-    """
-    An error is shown if a skip is given with bad arguments.
-    """
+    """An error is shown if a skip is given with bad arguments."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -1680,7 +1644,8 @@ def test_skip_bad_arguments(
 
 def test_custom_skip_markers_rst(tmp_path: Path) -> None:
     """
-    The next code block after a custom skip marker comment in a rST document is
+    The next code block after a custom skip marker comment in a rST
+    document is
     not run.
     """
     runner = CliRunner()
@@ -1734,7 +1699,8 @@ def test_custom_skip_markers_rst(tmp_path: Path) -> None:
 
 def test_default_skip_myst(tmp_path: Path) -> None:
     """
-    By default, the next code block after a 'skip doccmd: next' comment in a
+    By default, the next code block after a 'skip doccmd: next' comment
+    in a
     MyST document is not run.
     """
     runner = CliRunner()
@@ -1793,7 +1759,8 @@ def test_default_skip_myst(tmp_path: Path) -> None:
 
 def test_custom_skip_markers_myst(tmp_path: Path) -> None:
     """
-    The next code block after a custom skip marker comment in a MyST document
+    The next code block after a custom skip marker comment in a MyST
+    document
     is not run.
     """
     runner = CliRunner()
@@ -1855,7 +1822,8 @@ def test_custom_skip_markers_myst(tmp_path: Path) -> None:
 
 def test_multiple_skip_markers(tmp_path: Path) -> None:
     """
-    All given skip markers, including the default one, are respected.
+    All given skip markers, including the default one, are
+    respected.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -1917,9 +1885,7 @@ def test_multiple_skip_markers(tmp_path: Path) -> None:
 
 
 def test_skip_start_end(tmp_path: Path) -> None:
-    """
-    Skip start and end markers are respected.
-    """
+    """Skip start and end markers are respected."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     skip_marker_1 = uuid.uuid4().hex
@@ -1979,9 +1945,7 @@ def test_skip_start_end(tmp_path: Path) -> None:
 
 
 def test_duplicate_skip_marker(tmp_path: Path) -> None:
-    """
-    Duplicate skip markers are respected.
-    """
+    """Duplicate skip markers are respected."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     skip_marker = uuid.uuid4().hex
@@ -2035,9 +1999,7 @@ def test_duplicate_skip_marker(tmp_path: Path) -> None:
 
 
 def test_default_skip_marker_given(tmp_path: Path) -> None:
-    """
-    No error is shown when the default skip marker is given.
-    """
+    """No error is shown when the default skip marker is given."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     skip_marker = "all"
@@ -2090,7 +2052,8 @@ def test_default_skip_marker_given(tmp_path: Path) -> None:
 
 def test_skip_multiple(tmp_path: Path) -> None:
     """
-    It is possible to mark a code block as to be skipped by multiple markers.
+    It is possible to mark a code block as to be skipped by multiple
+    markers.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -2165,9 +2128,7 @@ def test_skip_multiple(tmp_path: Path) -> None:
 
 
 def test_bad_skips(tmp_path: Path) -> None:
-    """
-    Bad skip orders are flagged.
-    """
+    """Bad skip orders are flagged."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     skip_marker_1 = uuid.uuid4().hex
@@ -2209,9 +2170,7 @@ def test_bad_skips(tmp_path: Path) -> None:
 
 
 def test_empty_file(tmp_path: Path) -> None:
-    """
-    No error is shown when an empty file is given.
-    """
+    """No error is shown when an empty file is given."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     rst_file.touch()
@@ -2250,9 +2209,7 @@ def test_detect_line_endings(
     expect_cr: bool,
     expect_lf: bool,
 ) -> None:
-    """
-    The line endings of the original file are used in the new file.
-    """
+    """The line endings of the original file are used in the new file."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -2286,7 +2243,8 @@ def test_detect_line_endings(
 
 def test_one_supported_markup_in_another_extension(tmp_path: Path) -> None:
     """
-    Code blocks in a supported markup language in a file with an extension
+    Code blocks in a supported markup language in a file with an
+    extension
     which matches another extension are not run.
     """
     runner = CliRunner()
@@ -2325,9 +2283,7 @@ def test_one_supported_markup_in_another_extension(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(argnames="extension", argvalues=[".unknown", ""])
 def test_unknown_file_suffix(extension: str, tmp_path: Path) -> None:
-    """
-    An error is shown when the file suffix is not known.
-    """
+    """An error is shown when the file suffix is not known."""
     runner = CliRunner()
     document_file = tmp_path / ("example" + extension)
     content = textwrap.dedent(
@@ -2367,9 +2323,7 @@ def test_unknown_file_suffix(extension: str, tmp_path: Path) -> None:
 
 
 def test_custom_rst_file_suffixes(tmp_path: Path) -> None:
-    """
-    ReStructuredText files with custom suffixes are recognized.
-    """
+    """ReStructuredText files with custom suffixes are recognized."""
     runner = CliRunner()
     rst_file = tmp_path / "example.customrst"
     content = textwrap.dedent(
@@ -2473,9 +2427,7 @@ def test_markdown_code_block_line_number(tmp_path: Path) -> None:
 
 
 def test_norg(tmp_path: Path) -> None:
-    """
-    It is possible to run a command against a Norg file.
-    """
+    """It is possible to run a command against a Norg file."""
     runner = CliRunner()
     source_file = tmp_path / "example.norg"
     content = textwrap.dedent(
@@ -2523,9 +2475,7 @@ def test_norg(tmp_path: Path) -> None:
 
 
 def test_norg_in_directory(tmp_path: Path) -> None:
-    """
-    Norg files in a directory are discovered and processed.
-    """
+    """Norg files in a directory are discovered and processed."""
     runner = CliRunner()
     norg_file = tmp_path / "example.norg"
     norg_content = textwrap.dedent(
@@ -2556,9 +2506,7 @@ def test_norg_in_directory(tmp_path: Path) -> None:
 
 
 def test_custom_norg_extension(tmp_path: Path) -> None:
-    """
-    It is possible to use a custom extension for Norg files.
-    """
+    """It is possible to use a custom extension for Norg files."""
     runner = CliRunner()
     source_file = tmp_path / "example.custom_norg"
     content = textwrap.dedent(
@@ -2713,7 +2661,8 @@ def test_group_mdx_by_attribute_no_matches(
     *,
     tmp_path: Path,
 ) -> None:
-    """Code blocks without the grouping attribute are processed individually.
+    """Code blocks without the grouping attribute are processed
+    individually.
 
     This ensures the grouping feature degrades gracefully when blocks
     don't have the specified attribute.
@@ -3209,9 +3158,7 @@ def test_group_start_without_end(
     fail_on_parse_error_options: Sequence[str],
     expected_exit_code: int,
 ) -> None:
-    """
-    Error if a group is started but not ended.
-    """
+    """Error if a group is started but not ended."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -3252,9 +3199,7 @@ def test_group_start_without_end(
 
 
 def test_group_nested_start_without_end(tmp_path: Path) -> None:
-    """
-    Error if nested group start directives are not properly closed.
-    """
+    """Error if nested group start directives are not properly closed."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -3459,9 +3404,7 @@ def test_group_file_with_sphinx_jinja2_no_language(
 
 
 def test_custom_myst_file_suffixes(tmp_path: Path) -> None:
-    """
-    MyST files with custom suffixes are recognized.
-    """
+    """MyST files with custom suffixes are recognized."""
     runner = CliRunner()
     myst_file = tmp_path / "example.custommyst"
     content = textwrap.dedent(
@@ -3526,9 +3469,7 @@ def test_pty(
     options: Sequence[str],
     expected_output: str,
 ) -> None:
-    """
-    Test options for using pseudo-terminal.
-    """
+    """Test options for using pseudo-terminal."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     tty_test = textwrap.dedent(
@@ -3587,7 +3528,8 @@ def test_source_given_extension_no_leading_period(
     option: str,
 ) -> None:
     """
-    An error is shown when a given source file extension is given with no
+    An error is shown when a given source file extension is given with
+    no
     leading period.
     """
     runner = CliRunner()
@@ -3673,7 +3615,8 @@ def test_overlapping_extensions(tmp_path: Path) -> None:
 
 def test_overlapping_markdown_mdx_extensions(tmp_path: Path) -> None:
     """
-    An error is shown if there are overlapping extensions for Markdown and MDX.
+    An error is shown if there are overlapping extensions for Markdown
+    and MDX.
     """
     runner = CliRunner()
     source_file = tmp_path / "example.shared"
@@ -3717,7 +3660,8 @@ def test_overlapping_markdown_mdx_extensions(tmp_path: Path) -> None:
 
 def test_overlapping_markdown_djot_extensions(tmp_path: Path) -> None:
     """
-    An error is shown if there are overlapping extensions for Markdown and
+    An error is shown if there are overlapping extensions for Markdown
+    and
     Djot.
     """
     runner = CliRunner()
@@ -3761,9 +3705,7 @@ def test_overlapping_markdown_djot_extensions(tmp_path: Path) -> None:
 
 
 def test_overlapping_extensions_dot(tmp_path: Path) -> None:
-    """
-    No error is shown if multiple extension types are '.'.
-    """
+    """No error is shown if multiple extension types are '.'."""
     runner = CliRunner()
     source_file = tmp_path / "example.custom"
     content = textwrap.dedent(
@@ -3805,9 +3747,7 @@ def test_overlapping_extensions_dot(tmp_path: Path) -> None:
 
 
 def test_markdown(tmp_path: Path) -> None:
-    """
-    It is possible to run a command against a Markdown file.
-    """
+    """It is possible to run a command against a Markdown file."""
     runner = CliRunner()
     source_file = tmp_path / "example.md"
     content = textwrap.dedent(
@@ -3870,9 +3810,7 @@ def test_markdown(tmp_path: Path) -> None:
 
 
 def test_djot(tmp_path: Path) -> None:
-    """
-    It is possible to run a command against a Djot file.
-    """
+    """It is possible to run a command against a Djot file."""
     runner = CliRunner()
     source_file = tmp_path / "example.djot"
     content = textwrap.dedent(
@@ -3920,9 +3858,7 @@ def test_djot(tmp_path: Path) -> None:
 
 
 def test_djot_implicit_code_block_closure(tmp_path: Path) -> None:
-    """
-    Djot code blocks are correctly parsed when implicitly closed.
-    """
+    """Djot code blocks are correctly parsed when implicitly closed."""
     runner = CliRunner()
     source_file = tmp_path / "example.djot"
     # Code block inside a blockquote without an explicit closing fence
@@ -3964,9 +3900,7 @@ def test_djot_implicit_code_block_closure(tmp_path: Path) -> None:
 
 
 def test_mdx(tmp_path: Path) -> None:
-    """
-    It is possible to run a command against an MDX file.
-    """
+    """It is possible to run a command against an MDX file."""
     runner = CliRunner()
     source_file = tmp_path / "example.mdx"
     content = textwrap.dedent(
@@ -4009,7 +3943,8 @@ def test_mdx(tmp_path: Path) -> None:
 
 def test_mdx_parametrized_code_blocks(tmp_path: Path) -> None:
     """
-    MDX code blocks with parameters (like title) are correctly parsed.
+    MDX code blocks with parameters (like title) are correctly
+    parsed.
     """
     runner = CliRunner()
     source_file = tmp_path / "example.mdx"
@@ -4050,9 +3985,7 @@ def test_mdx_parametrized_code_blocks(tmp_path: Path) -> None:
 
 
 def test_directory(tmp_path: Path) -> None:
-    """
-    All source files in a given directory are worked on.
-    """
+    """All source files in a given directory are worked on."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     rst_content = textwrap.dedent(
@@ -4119,7 +4052,8 @@ def test_directory(tmp_path: Path) -> None:
 
 def test_de_duplication_source_files_and_dirs(tmp_path: Path) -> None:
     """
-    If a file is given which is within a directory that is also given, the file
+    If a file is given which is within a directory that is also given,
+    the file
     is de-duplicated.
     """
     runner = CliRunner()
@@ -4177,7 +4111,8 @@ def test_de_duplication_source_files_and_dirs(tmp_path: Path) -> None:
 
 def test_max_depth(tmp_path: Path) -> None:
     """
-    The --max-depth option limits the depth of directories to search for files.
+    The --max-depth option limits the depth of directories to search for
+    files.
     """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
@@ -4373,7 +4308,8 @@ def test_exclude_files_from_recursed_directories(tmp_path: Path) -> None:
 
 def test_multiple_exclude_patterns(tmp_path: Path) -> None:
     """
-    Files matching any of the exclude patterns are not processed when recursing
+    Files matching any of the exclude patterns are not processed when
+    recursing
     directories.
     """
     runner = CliRunner()
@@ -4461,7 +4397,8 @@ def test_lexing_exception(
     expected_exit_code: int,
 ) -> None:
     """
-    Lexing exceptions are handled when an invalid source file is given.
+    Lexing exceptions are handled when an invalid source file is
+    given.
     """
     runner = CliRunner()
     source_file = tmp_path / "invalid_example.md"
@@ -4645,9 +4582,7 @@ def test_modify_file_single_group_block(
     expected_exit_code: int,
     message_colour: Graphic,
 ) -> None:
-    """
-    Commands in groups cannot modify files in single grouped blocks.
-    """
+    """Commands in groups cannot modify files in single grouped blocks."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -4740,9 +4675,7 @@ def test_modify_file_multiple_group_blocks(
     expected_exit_code: int,
     message_colour: Graphic,
 ) -> None:
-    """
-    Commands in groups cannot modify files in multiple grouped commands.
-    """
+    """Commands in groups cannot modify files in multiple grouped commands."""
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -4823,9 +4756,7 @@ def test_modify_file_multiple_group_blocks(
 
 
 def test_jinja2(*, tmp_path: Path) -> None:
-    """
-    It is possible to run commands against sphinx-jinja2 blocks.
-    """
+    """It is possible to run commands against sphinx-jinja2 blocks."""
     runner = CliRunner()
     source_file = tmp_path / "example.rst"
     content = textwrap.dedent(
@@ -4877,9 +4808,7 @@ def test_jinja2(*, tmp_path: Path) -> None:
 
 
 def test_empty_language_given(*, tmp_path: Path) -> None:
-    """
-    An error is shown when an empty language is given.
-    """
+    """An error is shown when an empty language is given."""
     runner = CliRunner()
     source_file = tmp_path / "example.rst"
     content = ""
@@ -4911,7 +4840,8 @@ def test_empty_language_given(*, tmp_path: Path) -> None:
 
 
 def test_continue_on_error_multiple_files(tmp_path: Path) -> None:
-    """With --continue-on-error, execution continues across files when errors
+    """With --continue-on-error, execution continues across files when
+    errors
     occur.
 
     The tool collects all errors and exits with the highest error code.
@@ -4977,7 +4907,8 @@ def test_continue_on_error_multiple_files(tmp_path: Path) -> None:
 
 def test_continue_on_error_encoding_error(tmp_path: Path) -> None:
     """
-    With --continue-on-error and --fail-on-parse-error, encoding errors are
+    With --continue-on-error and --fail-on-parse-error, encoding errors
+    are
     collected and execution continues.
     """
     runner = CliRunner()
@@ -5071,7 +5002,8 @@ def test_continue_on_error_parse_error(tmp_path: Path) -> None:
 
 def test_continue_on_error_group_write_error(tmp_path: Path) -> None:
     """
-    With --continue-on-error and --fail-on-group-write, group write errors are
+    With --continue-on-error and --fail-on-group-write, group write
+    errors are
     collected and execution continues.
     """
     runner = CliRunner()
@@ -5133,7 +5065,8 @@ def test_continue_on_error_group_write_error(tmp_path: Path) -> None:
 
 
 def test_continue_on_error_command_not_found(tmp_path: Path) -> None:
-    """With --continue-on-error, OSError (command not found) is collected and
+    """With --continue-on-error, OSError (command not found) is collected
+    and
     execution continues.
 
     This covers the case where _EvaluateError is raised with a reason.

--- a/uv.lock
+++ b/uv.lock
@@ -485,13 +485,13 @@ dev = [
     { name = "check-manifest" },
     { name = "deptry" },
     { name = "doc8" },
-    { name = "docformatter" },
     { name = "furo" },
     { name = "hadolint-bin", marker = "sys_platform != 'win32'" },
     { name = "interrogate" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "mypy-strict-kwargs" },
     { name = "prek" },
+    { name = "pydocstringformatter" },
     { name = "pydocstyle" },
     { name = "pygments" },
     { name = "pylint", extra = ["spelling"] },
@@ -541,7 +541,6 @@ requires-dist = [
     { name = "cloup", specifier = ">=3.0.0" },
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.24.0" },
     { name = "doc8", marker = "extra == 'dev'", specifier = "==2.0.0" },
-    { name = "docformatter", marker = "extra == 'dev'", specifier = "==1.7.7" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "hadolint-bin", marker = "sys_platform != 'win32' and extra == 'dev'", specifier = "==2.14.0" },
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
@@ -549,6 +548,7 @@ requires-dist = [
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.0" },
+    { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==0.7.3" },
     { name = "pydocstyle", marker = "extra == 'dev'", specifier = "==6.3" },
     { name = "pygments", specifier = ">=2.18.0" },
     { name = "pygments", marker = "extra == 'dev'", specifier = "==2.19.2" },
@@ -582,19 +582,6 @@ requires-dist = [
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.22.0" },
 ]
 provides-extras = ["dev", "release"]
-
-[[package]]
-name = "docformatter"
-version = "1.7.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "charset-normalizer" },
-    { name = "untokenize" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/7b/ee08cb5fe2627ed0b6f0cc4a1c6be6c9c71de5a3e9785de8174273fc3128/docformatter-1.7.7.tar.gz", hash = "sha256:ea0e1e8867e5af468dfc3f9e947b92230a55be9ec17cd1609556387bffac7978", size = 26587, upload-time = "2025-05-11T04:54:04.356Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/b4/a7ec1eaee86761a9dbfd339732b4706db3c6b65e970c12f0f56cfcce3dcf/docformatter-1.7.7-py3-none-any.whl", hash = "sha256:7af49f8a46346a77858f6651f431b882c503c2f4442c8b4524b920c863277834", size = 33525, upload-time = "2025-05-11T04:54:03.353Z" },
-]
 
 [[package]]
 name = "docutils"
@@ -1434,6 +1421,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydocstringformatter"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/51/5c21963eb7bdba245ec808fdb0ef8abc0cd87ef674f2b6ba1fd76f3a0ffa/pydocstringformatter-0.7.3.tar.gz", hash = "sha256:dfcc07bec1706803d563275e282ef9e629b02dc19983ec6778d07a9f500bb62b", size = 24024, upload-time = "2023-01-02T15:09:30.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/38/b3a99e9cc66941e044ad3d40e90a72b1191925b8af13e3e4d8edc5c0eb87/pydocstringformatter-0.7.3-py3-none-any.whl", hash = "sha256:3654f52c49fc729b49712d1e7c49384dfd253bdffeda4939e79dab31491c563f", size = 31287, upload-time = "2023-01-02T15:09:28.904Z" },
 ]
 
 [[package]]
@@ -2462,12 +2461,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
-
-[[package]]
-name = "untokenize"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/46/e7cea8159199096e1df52da20a57a6665da80c37fb8aeb848a3e47442c32/untokenize-0.1.1.tar.gz", hash = "sha256:3865dbbbb8efb4bb5eaa72f1be7f3e0be00ea8b7f125c69cbd1f5fda926f37a2", size = 3099, upload-time = "2014-02-08T16:30:40.631Z" }
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
Replace docformatter with pydocstringformatter.

This follows the same pattern as https://github.com/VWS-Python/vws-python/pull/2793.

Changes:
- Replace `docformatter==1.7.7` with `pydocstringformatter==0.7.3`
- Update tool configuration in pyproject.toml
- Update ruff ignore rules (D200 → D205, D212)
- Format docstrings with new tool
- Workaround URL breaking issue by isolating URLs on their own lines where needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tooling change: docstring formatter swap**
> 
> - Replace `docformatter` with `pydocstringformatter` in `pyproject.toml`, `uv.lock`, and pre-commit hooks; add `[tool.pydocstringformatter]` config and remove `[tool.docformatter]`
> - Adjust Ruff ignores to match new formatter (`D205`, `D212`; per-file `D200` for `doccmd_*.py`); update CI skip list accordingly
> - Reformat docstrings project-wide (one-line summaries, wrapping, minor edits to isolate URLs) in code, tests, and docs; no runtime logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c11acd9952a5c9da4a031480a744909625a6757b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->