### PR TITLE
Remove --example-workers 0 due to mypy bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -372,8 +372,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="ty check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="ty
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -390,8 +390,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="pyrefly check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyrefly
+          check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
This removes `--example-workers 0` from the pre-commit config due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies docs-related pre-push hooks by relying on default `doccmd` worker behavior.
> 
> - Updates `ty-docs` and `pyrefly-docs` `entry` to `uv run --extra=dev doccmd --no-write-to-file --language=python --command="..."` (drops `--example-workers 0`) in `.pre-commit-config.yaml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 892a6f8f7ef5d83444ce6d771d5efb9baf740708. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->