### PR TITLE
Fix: Remove --example-workers 0 only from mypy-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -372,8 +372,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="ty
-          check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -390,8 +390,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyrefly
-          check"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyrefly check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
The previous PR incorrectly removed `--example-workers 0` from all hooks.

This PR reverts that and correctly removes it only from the `mypy-docs` hook, which is the one affected by the mypy bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts pre-commit doc checks to match intended configuration.
> 
> - Adds `--example-workers 0` to `ty-docs` and `pyrefly-docs` `doccmd` entries
> - Leaves `mypy-docs` without `--example-workers 0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db7ff512d75a92ff21ebe690d746f7559483435f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->