### PR TITLE
Fix Nuitka action parameter: use 'mode: onefile'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          onefile: true
+          mode: onefile
           output-file: doccmd-linux
 
       - name: Upload Linux binary artifact
@@ -328,7 +328,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          onefile: true
+          mode: onefile
           output-file: doccmd-macos
 
       - name: Upload macOS binary to release
@@ -372,7 +372,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          onefile: true
+          mode: onefile
           output-file: doccmd-windows
 
       - name: Upload Windows binary to release


### PR DESCRIPTION
The Nuitka-Action v1.4 uses `mode: onefile` instead of `onefile: true` to create single-file executables.

This fixes the release workflow failure: https://github.com/adamtheturtle/doccmd/actions/runs/21386361083/job/61563476954

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release workflow to correctly build single-file executables.
> 
> - Replace `onefile: true` with `mode: onefile` for Nuitka builds on Linux, macOS, and Windows in `release.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afe3add9aacd28622b412e65255875e3e0b3859e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->