### PR TITLE
Revert "Fix Nuitka action parameter: use 'mode: onefile'"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          mode: onefile
+          onefile: true
           output-file: doccmd-linux
 
       - name: Upload Linux binary artifact
@@ -328,7 +328,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          mode: onefile
+          onefile: true
           output-file: doccmd-macos
 
       - name: Upload macOS binary to release
@@ -372,7 +372,7 @@ jobs:
         with:
           nuitka-version: main
           script-name: bin/doccmd-wrapper.py
-          mode: onefile
+          onefile: true
           output-file: doccmd-windows
 
       - name: Upload Windows binary to release


### PR DESCRIPTION
Reverts adamtheturtle/doccmd#744

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates release workflow to correctly configure Nuitka one-file builds.
> 
> - Replaces `mode: onefile` with `onefile: true` for Linux, macOS, and Windows steps in `.github/workflows/release.yml`
> - No application code changes; only CI packaging configuration adjusted
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3046b70049abd97fa46902ea7787fab4d20bc38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->