### PR TITLE
Fix generated temporary filename to include source name and line number

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -90,9 +90,16 @@ class _TempFilePathMaker:
         Returns:
             A path to the temporary file.
         """
-        unique_id = uuid4().hex[:8]
-        filename = f"{self._prefix}_{unique_id}{self._suffix}"
-        return Path(example.path).parent / filename
+        source_path = Path(example.path)
+        # Sanitize the source filename (replace dots and dashes with _)
+        # Use .name (not .stem) to include the extension in the sanitized name
+        sanitized_source = source_path.name.replace(".", "_").replace("-", "_")
+        unique_id = uuid4().hex[:4]
+        filename = (
+            f"{self._prefix}_{sanitized_source}_l{example.line}__{unique_id}_"
+            f"{self._suffix}"
+        )
+        return source_path.parent / filename
 
 
 @beartype


### PR DESCRIPTION
## Summary

The `_TempFilePathMaker` was generating filenames without the source file name, making it difficult to identify which temporary file corresponds to which source file. This restores the previous naming format.

## Changes

- Include sanitized source filename (with extension) in temp file path
- Include line number of the code block
- Use 4-character unique identifier (not 8)
- Format: `{prefix}_{sanitized_source}_l{line}__{unique_id}_{suffix}`
- Example: `doccmd_readme_rst_l99__6b4d_.py`

## Testing

Added test to verify the temporary filename includes the source file name and line number. All 137 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores informative temp filename generation for code block execution.
> 
> - `_TempFilePathMaker` now builds filenames as `{prefix}_{sanitized_source}_l{line}__{id}_{suffix}`, where `sanitized_source` replaces `.` and `-` with `_` and `id` is 4 hex chars
> - Ensures the source filename (with extension) and example line number are embedded; paths are created in the source file’s directory
> - Adds test `test_temporary_file_includes_source_name` to verify sanitized source name and line inclusion
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053bda4ee4d113717f87e3edce3e6abe5d67aa69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->