### PR TITLE
Add ty unused-ignore-comment rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,6 +395,9 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 
+[tool.ty.rules]
+unused-ignore-comment = "warn"
+
 [tool.mypy_strict_kwargs]
 # `relative_to` and `is_relative_to` have `other` parameter that is
 # positional-only on Python 3.14+.


### PR DESCRIPTION
Add ty rule to warn on unused ignore comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures `ty` to surface unused ignore comments as warnings.
> 
> - Adds `[tool.ty.rules]` with `unused-ignore-comment = "warn"` in `pyproject.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 753b6d8c3fc23d244d02339a78d0371d929d1ab2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->