### PR TITLE
Add ty error-on-warning configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,8 +395,13 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 
-[tool.ty.rules]
-unused-ignore-comment = "warn"
+[tool.ty.analysis]
+# Disable support for `type: ignore` comments
+respect-type-ignore-comments = false
+
+[tool.ty.terminal]
+# Error if ty emits any warning-level diagnostics.
+error-on-warning = true
 
 [tool.mypy_strict_kwargs]
 # `relative_to` and `is_relative_to` have `other` parameter that is


### PR DESCRIPTION
Add ty configuration:
- respect-type-ignore-comments = false (for mypy compatibility)
- error-on-warning = true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `pyproject.toml` to tighten `ty` behavior.
> 
> - Replaces `tool.ty.rules` with `tool.ty.analysis` and `tool.ty.terminal`
> - Sets `respect-type-ignore-comments = false` to ignore `type: ignore` pragmas
> - Sets `error-on-warning = true` to treat warnings as errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5588bde9243ad0ec42b8217a46a1aaaf1261747. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->