### PR TITLE
Exit early on missing secrets in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,16 @@
 ---
 name: Release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      WINGET_TOKEN:
+        required: true
+      RELEASE_PAT:
+        required: true
+      HOMEBREW_TAP_GITHUB_TOKEN:
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low-risk YAML change, but it can impact the release pipeline if any caller workflows don’t pass the newly required secrets.
> 
> **Overview**
> Makes the `Release` GitHub Actions workflow reusable by adding a `workflow_call` trigger and declaring required secrets (`WINGET_TOKEN`, `RELEASE_PAT`, `HOMEBREW_TAP_GITHUB_TOKEN`) in addition to `workflow_dispatch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dbecf149b47f725413d2db28cc46f6548bb75bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->