### PR TITLE
Add pyrefly non-exhaustive match as error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,6 +349,9 @@ plugins = [
     "mypy_strict_kwargs",
 ]
 
+[tool.pyrefly]
+errors.non-exhaustive-match = "error"
+
 [tool.pyright]
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
@@ -443,6 +446,3 @@ exclude = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[tool.pyrefly]
-errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Adds \ to \ in project \ files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that tightens lint/type-checking behavior; risk is limited to potential new CI failures requiring code fixes.
> 
> **Overview**
> Adds a `pyrefly` configuration section to `pyproject.toml` to **treat `non-exhaustive-match` diagnostics as errors**, tightening static analysis rules during development/CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba8c190635d01c04df5a76c1638c580957d613d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->