### PR TITLE
Parallelize release workflow Docker publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
       id-token: write
       # This is needed for https://github.com/stefanzweifel/git-auto-commit-action.
       contents: write
-      # This is needed for pushing Docker images to ghcr.io.
-      packages: write
 
     steps:
       - uses: actions/checkout@v6
@@ -274,6 +272,22 @@ jobs:
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
+  publish-docker:
+    name: Publish Docker image
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      # This is needed for pushing Docker images to ghcr.io.
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.new_tag }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -296,8 +310,8 @@ jobs:
             docker buildx build \
               --push \
               --platform linux/amd64,linux/arm64 \
-              --build-arg DOCCMD_VERSION=${{ steps.calver.outputs.release }} \
-              --tag ghcr.io/adamtheturtle/doccmd:${{ steps.calver.outputs.release }} \
+              --build-arg DOCCMD_VERSION=${{ needs.build.outputs.new_tag }} \
+              --tag ghcr.io/adamtheturtle/doccmd:${{ needs.build.outputs.new_tag }} \
               --tag ghcr.io/adamtheturtle/doccmd:latest \
               .
 


### PR DESCRIPTION
## Summary
- move Docker image publishing out of the build job into a dedicated publish-docker job
- let Docker publishing run in parallel with macOS/Windows binary jobs after the release tag is created
- tighten build job permissions by removing unneeded packages: write

## Why
Docker publishing does not need to block downstream platform binary jobs, so separating it reduces critical-path release time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only refactor that mainly changes job structure and permissions; risk is limited to potential release pipeline failures or incorrect Docker tagging.
> 
> **Overview**
> Separates Docker image publishing from the main release job by introducing a dedicated `publish-docker` job that runs after `build`, allowing Docker publishing to proceed in parallel with macOS/Windows binary builds once the release tag exists.
> 
> Tightens `build` job permissions by removing `packages: write`, and updates Docker tagging/versioning to use `needs.build.outputs.new_tag` (and checks out that tag) for consistent image builds and tags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 094c3dfabfa03e1a32185b0ffa4448ce1bb4f9e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->