### PR TITLE
Enable coverage report.show_missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,8 +339,8 @@ report.exclude_also = [
     "class .*\\bProtocol\\):",
     "if TYPE_CHECKING:",
 ]
-
 report.show_missing = true
+
 [tool.mypy]
 strict = true
 files = [ "." ]


### PR DESCRIPTION
## Summary
- set \ \ in \

## Testing
- not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change affecting how coverage output is displayed, with no runtime or behavioral impact on the library.
> 
> **Overview**
> Enables `coverage.py`’s `report.show_missing = true` in `pyproject.toml`, so coverage reports will include explicit line/statement markers for untested code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a56946ab7f97ca50d1778c0af2502e3ff1066438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->