### PR TITLE
Use native pytest TOML configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,8 +325,8 @@ keep_full_version = true
 max_supported_python = "3.14"
 
 [tool.pytest]
-ini_options.xfail_strict = true
-ini_options.log_cli = true
+xfail_strict = true
+log_cli = true
 
 [tool.coverage]
 run.branch = true


### PR DESCRIPTION
## Summary
- Remove `ini_options.` prefix from pytest configuration keys under `[tool.pytest]`
- Uses the native TOML configuration format supported since pytest 9.0
- See: https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `pyproject.toml` pytest configuration key names with no runtime code changes; risk is limited to potential test-run config differences if an older pytest version is used.
> 
> **Overview**
> Updates pytest configuration in `pyproject.toml` to use pytest’s native TOML key names by removing the `ini_options.` prefix (e.g., `xfail_strict` and `log_cli`). This aligns the project with pytest 9+ TOML configuration expectations without changing application code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeb6746a20f39af50eb77b2840f0853f555f5a25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->