### PR TITLE
Add --pycon-language option for configurable pycon stripping

### DIFF
--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -617,6 +617,67 @@ def test_modify_file_pycon_code_block(tmp_path: Path) -> None:
     assert rst_file.read_text(encoding="utf-8") == expected_content
 
 
+def test_custom_pycon_language(tmp_path: Path) -> None:
+    """The --pycon-language option allows using pycon stripping for non-
+    default language names.
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python-console
+
+            >>> x=1+  2
+            >>> x
+            3
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    format_code_script = textwrap.dedent(
+        text="""\
+        import ast
+        import sys
+        from pathlib import Path
+
+        path = Path(sys.argv[1])
+        source = path.read_text(encoding="utf-8")
+        ast.parse(source)
+        path.write_text(
+            source.replace("x=1+  2", "x = 1 + 2"),
+            encoding="utf-8",
+        )
+        """,
+    )
+    format_code_file = tmp_path / "format_code.py"
+    format_code_file.write_text(data=format_code_script, encoding="utf-8")
+    result = runner.invoke(
+        cli=main,
+        args=[
+            "--language",
+            "python-console",
+            "--pycon-language",
+            "python-console",
+            "--command",
+            f"{Path(sys.executable).as_posix()} {format_code_file.as_posix()}",
+            "--no-pad-file",
+            str(object=rst_file),
+        ],
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    expected_content = textwrap.dedent(
+        text="""\
+        .. code-block:: python-console
+
+            >>> x = 1 + 2
+            >>> x
+            3
+        """,
+    )
+    assert rst_file.read_text(encoding="utf-8") == expected_content
+
+
 def test_exit_code(tmp_path: Path) -> None:
     """The exit code of the first failure is propagated."""
     runner = CliRunner()

--- a/tests/test_doccmd/test_help.txt
+++ b/tests/test_doccmd/test_help.txt
@@ -14,6 +14,15 @@ Code block selection:
                                   languages. If this is not given, no code
                                   blocks are run, unless `--sphinx-jinja2` is
                                   given.
+  --pycon-language TEXT           Treat code blocks for this language as pycon
+                                  (Python interactive console) blocks, stripping
+                                  ``>>>`` and ``...`` prompts before passing the
+                                  code to the command and restoring them
+                                  afterward. Give this multiple times to use
+                                  pycon stripping for multiple languages. To
+                                  disable pycon stripping for all languages,
+                                  including the default, use `--pycon-
+                                  language=.`.  [default: pycon]
   --skip-marker TEXT              The marker used to identify code blocks to be
                                   skipped.
                                   


### PR DESCRIPTION
## Summary

Replaces hardcoded `pycon` language with a configurable `--pycon-language` option. Users can now specify which code block languages should use pycon stripping (removing `>>>` and `...` prompts). The option supports multiple values and defaults to `("pycon",)` for backward compatibility. Use `--pycon-language=.` to disable pycon stripping entirely.

This mirrors the pattern used for file extension options like `--myst-extension`, providing consistent UI across the codebase.

## Test Plan

- Added `test_custom_pycon_language` to verify pycon stripping works with non-default language names
- All 155 existing tests pass, including the original `test_modify_file_pycon_code_block`
- Regression test for help text updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an opt-in CLI option and threads it through evaluator selection while keeping the default `pycon` behavior; main risk is minor behavior changes if users customize/disable pycon handling.
> 
> **Overview**
> Adds `--pycon-language` (multi-value, default `pycon`) to control which code block languages are treated as pycon/interactive-console blocks, and uses membership checks (`language in pycon_languages`) instead of the previously hardcoded `language == "pycon"` when selecting the pycon evaluator.
> 
> Updates tests to cover a custom pycon-like language and refreshes the CLI help-text regression output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9772aa4f3844cbd77057614baa6c328aec8ac409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->