### PR TITLE
ci: bump astral-sh/setup-uv from v7 to v8.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'


### PR DESCRIPTION
## Summary
- Bumps \`astral-sh/setup-uv\` from v7 to v8.1.0 across all GitHub Actions workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the `astral-sh/setup-uv` GitHub Action version in CI/lint/release workflows, with no application code changes; main risk is workflow behavior changes if the action has breaking updates.
> 
> **Overview**
> Updates GitHub Actions workflows to use `astral-sh/setup-uv@v8.1.0` instead of `v7` in `ci.yml`, `lint.yml`, and `release.yml`, keeping the same caching configuration and job steps otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ea922213ab65633dc546bd207a940b55cfc3d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->