### PR TITLE
Use thread-safe skip parser from sybil-extras

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -48,9 +48,11 @@ reco
 recursing
 repo
 rst
+simplistix
 stderr
 strikethrough
 subdirectories
+sybil
 symlink
 symlinked
 symlinks

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -944,7 +944,7 @@ def _get_sybil(
     )
 
     skip_parsers = [
-        markup_language.skip_parser_cls(
+        markup_language.thread_safe_skip_parser_cls(
             directive=skip_directive,
         )
         for skip_directive in skip_directives

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -2686,6 +2686,82 @@ def test_skip_multiple(tmp_path: Path) -> None:
     assert result.stderr == ""
 
 
+def test_skip_with_parallel_workers(tmp_path: Path) -> None:
+    """Skip directives are honored under concurrent example evaluation.
+
+    Exercises sybil-extras' ``ThreadSafeSkipParser``: a single document
+    with many code blocks, ``skip: next`` directives, and a ``skip:
+    start``/``skip: end`` interval is evaluated with
+    ``--example-workers`` greater than one. The exact set of non-skipped
+    blocks must execute on every iteration; output ordering may
+    interleave so membership (not ordering) is asserted. The loop shakes
+    out skip-state races such as simplistix/sybil#166.
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    block_lines: list[str] = []
+    expected_run: set[str] = set()
+    expected_skipped: set[str] = set()
+
+    def _block(name: str) -> str:
+        """Return an rST code block printing ``name``."""
+        return textwrap.dedent(
+            text=f"""\
+            .. code-block:: python
+
+                print("{name}")
+
+            """,
+        )
+
+    skip_next_indices = {3, 7, 11, 15}
+    skip_start_index = 5
+    skip_end_index = 6
+    for index in range(20):
+        name = f"block_{index}"
+        if index in skip_next_indices:
+            block_lines.append(".. skip doccmd[all]: next\n\n")
+            block_lines.append(_block(name=name))
+            expected_skipped.add(name)
+        elif index == skip_start_index:
+            block_lines.append(".. skip doccmd[all]: start\n\n")
+            block_lines.append(_block(name=name))
+            expected_skipped.add(name)
+        elif index == skip_end_index:
+            block_lines.append(_block(name=name))
+            block_lines.append(".. skip doccmd[all]: end\n\n")
+            expected_skipped.add(name)
+        else:
+            block_lines.append(_block(name=name))
+            expected_run.add(name)
+
+    rst_file.write_text(data="".join(block_lines), encoding="utf-8")
+
+    for _ in range(5):
+        result = runner.invoke(
+            cli=main,
+            args=[
+                "--no-pad-file",
+                "--no-write-to-file",
+                "--language",
+                "python",
+                "--command",
+                "python",
+                "--example-workers",
+                "8",
+                str(object=rst_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, (result.stdout, result.stderr)
+        printed = set(result.stdout.split())
+        assert expected_run <= printed, (expected_run - printed, result.stdout)
+        assert not expected_skipped & printed, (
+            expected_skipped & printed,
+            result.stdout,
+        )
+
+
 def test_bad_skips(tmp_path: Path) -> None:
     """Bad skip orders are flagged."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- Switch to `markup_language.thread_safe_skip_parser_cls` so skip directives are evaluated safely under doccmd's `ThreadPoolExecutor`-based example/document parallelism.
- Upstream sybil's `Skipper` mutates per-document state during evaluation (simplistix/sybil#166); the sybil-extras `ThreadSafeSkipParser` resolves decisions under a per-document lock with cached conditional `if` evaluation.

## Test plan
- [x] `uv run pytest tests/ -k skip` (14 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the skip-directive parser used during Sybil parsing, which can affect which examples execute when `--example-workers` is enabled. Main risk is behavioral regression in skip handling across markup languages, though it is covered by a new concurrency-focused test.
> 
> **Overview**
> Switches skip directive handling in `doccmd` to use `markup_language.thread_safe_skip_parser_cls`, avoiding shared mutable skip state when evaluating examples concurrently.
> 
> Adds a regression test that runs many rST code blocks with a mix of `skip: next` and `skip: start/end` directives under `--example-workers>1`, asserting skipped blocks never execute even with interleaved output. Also updates the private spelling dictionary for `simplistix` and `sybil`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abae6a0e19f292064482f9f77b8adb97483e9632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->