### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,6 +176,7 @@ repos:
         name: mypy
         stages: [pre-push]
         entry: uv run --extra=dev -m mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -186,6 +187,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        args: [--num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,8 +175,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -186,8 +185,9 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers=4"
+        entry: >-
+          uv run --extra=dev doccmd --no-write-to-file --language=python
+          --command="mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,8 +186,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
-        args: [--num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-commit hook args
- add `--num-workers=4` to the `mypy-docs` pre-commit hook args

## Test plan
- [x] pre-commit hooks passed during commit
- [x] pre-push hooks passed during branch push

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes `pre-push` hook command-line flags for `mypy`/`mypy-docs`, affecting developer/CI lint performance rather than runtime behavior.
> 
> **Overview**
> Updates the `pre-push` `mypy` and `mypy-docs` pre-commit hooks to run `mypy` with `--num-workers=4`, enabling parallel type-checking (including when invoked via `doccmd`).
> 
> Also reformats the `mypy-docs` hook `entry` into a multi-line YAML scalar for readability while preserving behavior aside from the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554e24ea4372753314d886338ebdfcd79a790c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->