### PR TITLE
Fail pylint on useless suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,9 @@ MASTER.unsafe-load-any-extension = false
 MASTER.ignore = [
     "_setuptools_scm_version.py",
 ]
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1498,7 +1498,7 @@ def test_workers_zero_requires_no_write_when_auto_parallel(
         """,
     )
     rst_file.write_text(data=content, encoding="utf-8")
-    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: 4)  # pylint: disable=bad-builtin
+    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: 4)
     result = runner.invoke(
         cli=main,
         args=[
@@ -1540,7 +1540,7 @@ def test_workers_zero_allows_running_when_cpu_is_single(
         """,
     )
     rst_file.write_text(data=content, encoding="utf-8")
-    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: 1)  # pylint: disable=bad-builtin
+    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: 1)
     result = runner.invoke(
         cli=main,
         args=[
@@ -1574,7 +1574,7 @@ def test_cpu_count_returns_none(
         """,
     )
     rst_file.write_text(data=content, encoding="utf-8")
-    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: None)  # pylint: disable=bad-builtin
+    monkeypatch.setattr(target=os, name="cpu_count", value=lambda: None)
     result = runner.invoke(
         cli=main,
         args=[


### PR DESCRIPTION
## Summary
- Make Pylint return a failing exit code when it reports `useless-suppression`.
- Remove obsolete `bad-builtin` disables around `monkeypatch.setattr`.

## Validation
- `uv run --extra dev pylint src/ tests/ --score=n`
- `uv run --extra dev pyproject-fmt pyproject.toml`
- Pre-commit hooks ran during commit and pre-push hooks ran during push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only lint configuration and test comment cleanup; no runtime behavior changes.
> 
> **Overview**
> Updates `pyproject.toml` to make Pylint exit non-zero when it reports `useless-suppression`, tightening CI/lint enforcement.
> 
> Cleans up `tests/test_doccmd.py` by removing now-unneeded `# pylint: disable=bad-builtin` pragmas around `monkeypatch.setattr` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165fce705695db4f05afcf870c89057fcd8484e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->