### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ optional-dependencies.dev = [
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",
     "homebrew-pypi-poet==0.10",
+    "towncrier==25.8.0",
 ]
 urls.Documentation = "https://adamtheturtle.github.io/doccmd/"
 urls.Source = "https://github.com/adamtheturtle/doccmd"

--- a/uv.lock
+++ b/uv.lock
@@ -546,6 +546,7 @@ dev = [
 release = [
     { name = "check-wheel-contents" },
     { name = "homebrew-pypi-poet" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -599,6 +600,7 @@ requires-dist = [
     { name = "sybil", specifier = ">=9.3.0,<11.0.0" },
     { name = "sybil-extras", specifier = "==2026.5.6" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
+    { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "types-pygments", marker = "extra == 'dev'", specifier = "==2.20.0.20260518" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change: adds `towncrier` to the `release` extra so release jobs can run `towncrier build` without installing dev dependencies.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency group in `pyproject.toml` so release workflows can invoke `towncrier` when installing only `--extra=release`.
> 
> Updates `uv.lock` to reflect the new `release` extra membership and corresponding `requires-dist` marker entry for `towncrier`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce978e5c5e0dff9ff858ed9ecf3046db9fd8cfd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->