### PR TITLE
Remove obsolete cloup issue 200 comments

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -1156,7 +1156,6 @@ def _get_sybil(
 # Option decorators expose an unknown parameter type to pyright.
 @cloup.option_group(
     "Required options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "command",
         "-c",
@@ -1168,7 +1167,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Code block selection",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "languages",
         "-l",
@@ -1189,7 +1187,6 @@ def _get_sybil(
             ]
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--pycon-language",
         "pycon_languages",
@@ -1214,7 +1211,6 @@ def _get_sybil(
             ]
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--detect-pycon-language",
         "detect_pycon_languages",
@@ -1241,7 +1237,6 @@ def _get_sybil(
             ]
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "skip_markers",
         "--skip-marker",
@@ -1273,7 +1268,6 @@ def _get_sybil(
         multiple=True,
         callback=_deduplicate,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--sphinx-jinja2/--no-sphinx-jinja2",
         "sphinx_jinja2",
@@ -1289,7 +1283,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Grouping options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "group_markers",
         "--group-marker",
@@ -1320,7 +1313,6 @@ def _get_sybil(
         multiple=True,
         callback=_deduplicate,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--group-file/--no-group-file",
         "group_file",
@@ -1337,7 +1329,6 @@ def _get_sybil(
             "them."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--pad-groups/--no-pad-groups",
         is_flag=True,
@@ -1352,7 +1343,6 @@ def _get_sybil(
             "they generally need to look at the file without padding."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--fail-on-group-write/--no-fail-on-group-write",
         "fail_on_group_write",
@@ -1365,7 +1355,6 @@ def _get_sybil(
             "``doccmd`` does not support writing to grouped code blocks."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "group_mdx_by_attribute",
         "--group-mdx-by-attribute",
@@ -1389,7 +1378,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Temporary file options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "temporary_file_extension",
         "--temporary-file-extension",
@@ -1402,7 +1390,6 @@ def _get_sybil(
         ),
         callback=_validate_file_extension_or_none,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "temporary_file_name_prefix",
         "--temporary-file-name-prefix",
@@ -1417,7 +1404,6 @@ def _get_sybil(
             "configurations."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "temporary_file_name_template",
         "--temporary-file-name-template",
@@ -1437,7 +1423,6 @@ def _get_sybil(
             "Example: '{prefix}_{unique}{suffix}' produces 'doccmd_a1b2.py'."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--pad-file/--no-pad-file",
         is_flag=True,
@@ -1451,7 +1436,6 @@ def _get_sybil(
             "they generally need to look at the file without padding."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--write-to-file/--no-write-to-file",
         "write_to_file",
@@ -1467,7 +1451,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "File discovery options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--rst-extension",
         "rst_suffixes",
@@ -1484,7 +1467,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--myst-extension",
         "myst_suffixes",
@@ -1501,7 +1483,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--markdown-extension",
         "markdown_suffixes",
@@ -1516,7 +1497,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--mdx-extension",
         "mdx_suffixes",
@@ -1530,7 +1510,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--djot-extension",
         "djot_suffixes",
@@ -1544,7 +1523,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--norg-extension",
         "norg_suffixes",
@@ -1558,7 +1536,6 @@ def _get_sybil(
         show_default=True,
         callback=_validate_file_extensions,
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--max-depth",
         type=click.IntRange(min=1),
@@ -1566,7 +1543,6 @@ def _get_sybil(
         show_default=False,
         help="Maximum depth to search for files in directories.",
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--exclude",
         "exclude_patterns",
@@ -1579,7 +1555,6 @@ def _get_sybil(
             "Use forward slashes on all platforms."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--respect-gitignore/--no-respect-gitignore",
         "respect_gitignore",
@@ -1595,7 +1570,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Execution options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--use-pty",
         "use_pty_option",
@@ -1616,7 +1590,6 @@ def _get_sybil(
             "'detect': Automatically determine based on environment (default)."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--example-workers",
         type=click.IntRange(min=0),
@@ -1632,7 +1605,6 @@ def _get_sybil(
             "Output may be interleaved when using parallel execution."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--document-workers",
         type=click.IntRange(min=0),
@@ -1651,7 +1623,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Error handling",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--fail-on-parse-error/--no-fail-on-parse-error",
         "fail_on_parse_error",
@@ -1663,7 +1634,6 @@ def _get_sybil(
             "parsed."
         ),
     ),
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--continue-on-error/--no-continue-on-error",
         "continue_on_error",
@@ -1680,7 +1650,6 @@ def _get_sybil(
 )
 @cloup.option_group(
     "Output options",
-    # See https://github.com/janluke/cloup/issues/200.
     cloup.option(
         "--verbose",
         "-v",


### PR DESCRIPTION
Removes 31 now-unnecessary `# See https://github.com/janluke/cloup/issues/200.` comments from `src/doccmd/__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only deletion in the CLI module; no runtime, API, or configuration impact.
> 
> **Overview**
> Removes **31** obsolete inline comments (`# See https://github.com/janluke/cloup/issues/200.`) from the `doccmd` CLI definition in `src/doccmd/__init__.py`, on `@cloup.option_group` blocks and individual `@cloup.option` decorators.
> 
> **No behavior, types, or CLI surface changes**—only comment cleanup now that the referenced cloup/pyright issue is resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b660563940c0f945b4e96c231722e484f92cdd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->