### PR TITLE
Reject empty --exclude patterns

### DIFF
--- a/newsfragments/1216.change.rst
+++ b/newsfragments/1216.change.rst
@@ -1,0 +1,1 @@
+Reject an empty ``--exclude`` pattern with a usage error instead of crashing.

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -1548,6 +1548,12 @@ def _get_sybil(
         "exclude_patterns",
         type=str,
         multiple=True,
+        callback=multi_callback(
+            callbacks=[
+                _deduplicate,
+                sequence_validator(validator=_validate_no_empty_string),
+            ]
+        ),
         help=(
             "A glob-style pattern that matches file paths to ignore while "
             "recursively discovering files in directories. "

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1167,6 +1167,43 @@ def test_invalid_template_placeholder(tmp_path: Path) -> None:
     assert result.output == expected_output
 
 
+def test_empty_exclude_pattern(tmp_path: Path) -> None:
+    """An error is raised for an empty ``--exclude`` pattern."""
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--exclude",
+        "",
+        "--command",
+        "echo",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    expected_output = (
+        "Usage: doccmd [OPTIONS] [DOCUMENT_PATHS]...\n"
+        "Try 'doccmd --help' for help.\n"
+        "\n"
+        "Error: Invalid value for '--exclude': "
+        "This value cannot be empty.\n"
+    )
+    assert result.output == expected_output
+
+
 @pytest.mark.parametrize(
     argnames="template",
     argvalues=[


### PR DESCRIPTION
## Problem

`--exclude` accepted an empty string. During recursive directory discovery in `_get_file_paths`, the empty value was passed to `Path.match`, which raises `ValueError("empty pattern")`, producing an uncaught traceback (exit 1).

## Fix

Validate `--exclude` during Click option parsing, reusing the same callback pattern as `--language`:

```python
callback=multi_callback(
    callbacks=[
        _deduplicate,
        sequence_validator(validator=_validate_no_empty_string),
    ]
)
```

An empty pattern is now rejected with a concise usage error (exit 2) and the existing message "This value cannot be empty.", while deduplication behaviour stays consistent with other `multiple=True` options.

A regression test asserts the exact usage-error output, and a newsfragment was added.

Fixes #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI validation change aligned with existing callbacks; no auth, data, or discovery logic beyond early rejection of invalid input.
> 
> **Overview**
> **`--exclude`** now validates each glob pattern during CLI parsing, matching **`--language`** and related multi-value options: values are deduplicated and empty strings are rejected with *"This value cannot be empty."* instead of failing later during directory discovery.
> 
> Previously an empty pattern could reach **`Path.match`**, trigger **`ValueError: empty pattern`**, and exit with an uncaught traceback. A regression test locks in the usage-error output, and a newsfragment documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c373cb2c2f78d721b1dbf70c3e86ed7f6f0cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->