### PR TITLE
Keep generated temporary filenames simple and portable

### DIFF
--- a/newsfragments/1214.change.rst
+++ b/newsfragments/1214.change.rst
@@ -1,0 +1,1 @@
+Always generate a valid Python module name for temporary files so linters do not flag ``doccmd``'s own filenames (`#1214 <https://github.com/adamtheturtle/doccmd/issues/1214>`_).

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -3,6 +3,7 @@
 import difflib
 import os
 import platform
+import re
 import shlex
 import shutil
 import subprocess
@@ -122,16 +123,26 @@ class _TempFilePathMaker:
             A path to the temporary file.
         """
         source_path = Path(example.path)
-        # Sanitize the source filename: replace dots and dashes with ``_``
-        # and lower-case it. Use ``.name`` (not ``.stem``) to include the
-        # extension. Lower-casing keeps the generated name a valid module
-        # name now that each temporary file lives in its own package
-        # directory, so tools such as ``ruff`` (rule ``N999``) do not
-        # flag it for a source document with upper-case letters in its
-        # name (for example ``README.rst``).
-        sanitized_source = (
-            source_path.name.replace(".", "_").replace("-", "_").lower()
+        # Sanitize the source filename into a valid Python module name.
+        # Use ``.name`` (not ``.stem``) to include the extension, then
+        # lower-case it and replace every character that is not a valid
+        # Python identifier character (i.e. not alphanumeric and not
+        # ``_``) with ``_``. This subsumes replacing dots and dashes (and
+        # spaces) with ``_``. If the result starts with a digit, prefix
+        # it with ``_`` because module names cannot start with a digit.
+        # Keeping the generated name a valid module name means that tools
+        # such as ``ruff`` (rule ``N999``) do not flag it for a source
+        # document whose name would otherwise be invalid (for example
+        # ``README.rst`` with upper-case letters or ``123 bad.rst`` with a
+        # leading digit and a space).
+        raw_name = source_path.name.lower()
+        sanitized_source = re.sub(
+            pattern=r"[^0-9a-z_]",
+            repl="_",
+            string=raw_name,
         )
+        if sanitized_source and sanitized_source[0].isdigit():
+            sanitized_source = f"_{sanitized_source}"
         unique_id = uuid4().hex[:4]
         filename = self._template.format(
             prefix=self._prefix,

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1303,6 +1303,43 @@ def test_temporary_file_includes_source_name(tmp_path: Path) -> None:
     assert "_l1__" in output_path.name
 
 
+def test_temporary_file_name_is_valid_module_name(tmp_path: Path) -> None:
+    """
+    The temporary file name is a valid Python module name even when the
+    source file name is not (for example a leading digit and a space).
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "123 bad.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+            assert x == 4
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--command",
+        "echo",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    output = result.stdout
+    output_path = Path(output.strip())
+    stem = output_path.stem
+    assert stem.isidentifier(), stem
+    assert not stem[0].isdigit(), stem
+
+
 def test_file_extension_unknown_language(tmp_path: Path) -> None:
     """
     The file extension of the temporary file is `.txt` for any unknown


### PR DESCRIPTION
Fixes #1214.

`_TempFilePathMaker` builds the temporary filename from the source document's name. Previously it only replaced dots and dashes and lower-cased the result, so a valid documentation filename such as `123 bad.rst` produced a temp filename containing a space and a leading digit (`doccmd_123 bad_rst_l1__d3fe_.py`).

This keeps the generated name **simple and portable** — every character that is not alphanumeric or `_` is replaced with `_`, dropping spaces and other awkward characters, and a leading digit is prefixed with `_`. The name is then safe to hand to whatever command runs against it, regardless of language.

As a secondary benefit for Python code blocks, the name is also a valid module name, so linters that check module names (e.g. `ruff`'s `N999`) no longer flag doccmd's own generated filename. That is a bonus, not the primary motivation — most doccmd usage is not Python.

Behaviour is otherwise unchanged; added a regression test and a newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)