### PR TITLE
Support UTF-16 documents in newline detection

### DIFF
--- a/newsfragments/1215.change.rst
+++ b/newsfragments/1215.change.rst
@@ -1,0 +1,1 @@
+Support UTF-16 documents by detecting newlines on the decoded text (`#1215 <https://github.com/adamtheturtle/doccmd/issues/1215>`_).

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -488,10 +488,10 @@ def _log_error(message: str) -> None:
 
 
 @beartype
-def _detect_newline(content_bytes: bytes) -> bytes | None:
+def _detect_newline(content: str) -> str | None:
     """Detect the newline character used in the content."""
-    for newline in (b"\r\n", b"\n", b"\r"):
-        if newline in content_bytes:
+    for newline in ("\r\n", "\n", "\r"):
+        if newline in content:
             return newline
     return None
 
@@ -706,10 +706,8 @@ def _process_file_path(
         return local_errors
 
     content_bytes = file_path.read_bytes()
-    newline_bytes = _detect_newline(content_bytes=content_bytes)
-    newline = (
-        newline_bytes.decode(encoding=encoding) if newline_bytes else None
-    )
+    content_str = content_bytes.decode(encoding=encoding)
+    newline = _detect_newline(content=content_str)
     sybils_with_makers: Sequence[_SybilWithTempFileMaker] = []
     for code_block_language in languages:
         temporary_file_extension = _get_temporary_file_extension(

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -220,6 +220,42 @@ def test_unknown_encoding(
     assert result.stderr == expected_stderr
 
 
+def test_utf_16_file_given(tmp_path: Path) -> None:
+    """A UTF-16 document is processed and its newline is preserved.
+
+    Newlines are detected on the decoded text rather than the raw
+    bytes, so a UTF-16 document does not crash during newline
+    detection.
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            block_1
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-16", newline="\r\n")
+    arguments = [
+        "--no-pad-file",
+        "--language",
+        "python",
+        "--command",
+        "cat",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert result.stderr == ""
+    assert result.stdout_bytes.decode(encoding="utf-16") == "block_1\r\n"
+
+
 def test_multiple_code_blocks(tmp_path: Path) -> None:
     """
     It is possible to run a command against multiple code blocks in a


### PR DESCRIPTION
## Summary

UTF-16 documents previously crashed during newline detection. `_detect_newline` searched the raw bytes for single-byte `b"\n"`/`b"\r"` delimiters and returned raw bytes, which `_process_file_path` then decoded with the document's encoding. For UTF-16, `b"\n"` is only half of an encoded newline, so `b"\n".decode("utf-16-le")` raised an uncaught `UnicodeDecodeError` (exit 1).

This change operates on the decoded text instead:

- `_detect_newline` now accepts decoded `str` and returns `str | None`.
- `_process_file_path` decodes the bytes with the detected encoding first (which also consumes any BOM) and then detects the newline as text.

UTF-16 documentation is now parsed and evaluated, preserving its newline convention like other non-UTF-8 encodings. A regression test creates a UTF-16 `.rst` file with a Python code block, runs `doccmd --command cat`, and asserts exit code 0 with the CRLF newline preserved.

Fixes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to encoding/newline handling with a targeted regression test; no auth, security, or broad API surface impact.
> 
> **Overview**
> Fixes **UTF-16 documents** crashing during processing because newline detection ran on raw bytes and then tried to decode isolated `b"\n"` / `b"\r"` sequences with the file encoding.
> 
> **`_detect_newline`** now takes decoded `str` and returns `str | None` (still preferring `\r\n`, then `\n`, then `\r`). **`_process_file_path`** decodes the file with the detected encoding first, then detects the newline on that text—so wide-character encodings work and BOM handling stays in the decode step.
> 
> Adds a regression test for a UTF-16 `.rst` with CRLF and a newsfragment for #1215.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e19dfb41e8541351e2873459bf9b9e5bb951cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->