### PR TITLE
Reject temporary-file-name templates that escape the isolation directory

### DIFF
--- a/newsfragments/1211.change.rst
+++ b/newsfragments/1211.change.rst
@@ -1,0 +1,1 @@
+Reject ``--temporary-file-name-template`` values that could resolve outside the temporary directory, preventing accidental overwrite or deletion of unrelated files. See `#1211 <https://github.com/adamtheturtle/doccmd/issues/1211>`__.

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -158,7 +158,7 @@ class _TempFilePathMaker:
             self._created_directories.append(directory)
         final_path = directory / filename
         # Defense in depth: ``_validate_template`` guarantees that the
-        # formatted file name is a basename confined to ``directory``, so
+        # formatted file name is a base name confined to ``directory``, so
         # the resolved parent must be ``directory`` itself. A violation
         # would mean the file could escape the isolation directory.
         assert final_path.parent == directory  # noqa: S101
@@ -295,17 +295,15 @@ def _validate_template(
     # Reject templates that could resolve outside the per-example
     # isolation directory. The formatted name is joined directly to a
     # freshly-created directory, so it must be a single safe path
-    # component (a basename): no path separators, parent references, or
+    # component (a base name): no path separators, parent references, or
     # absolute paths. Both separator conventions are treated as
     # separators regardless of the host OS.
-    if (
-        "/" in formatted
-        or "\\" in formatted
-        or PurePosixPath(formatted).is_absolute()
-        or PureWindowsPath(formatted).is_absolute()
-        or ".." in PurePosixPath(formatted).parts
-        or ".." in PureWindowsPath(formatted).parts
-    ):
+    posix_path = PurePosixPath(formatted)
+    windows_path = PureWindowsPath(formatted)
+    has_separator = any(separator in formatted for separator in ("/", "\\"))
+    is_absolute = posix_path.is_absolute() or windows_path.is_absolute()
+    has_parent_reference = ".." in (*posix_path.parts, *windows_path.parts)
+    if has_separator or is_absolute or has_parent_reference:
         message = (
             "Template must produce a file name within the temporary "
             "directory: it may not contain path separators, parent "

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
 from enum import Enum, auto, unique
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from threading import Lock
 from typing import TypeVar
 from uuid import uuid4
@@ -156,7 +156,13 @@ class _TempFilePathMaker:
         )
         with self._lock:
             self._created_directories.append(directory)
-        return directory / filename
+        final_path = directory / filename
+        # Defense in depth: ``_validate_template`` guarantees that the
+        # formatted file name is a basename confined to ``directory``, so
+        # the resolved parent must be ``directory`` itself. A violation
+        # would mean the file could escape the isolation directory.
+        assert final_path.parent == directory  # noqa: S101
+        return final_path
 
     def cleanup(self) -> None:
         """Remove every directory created for this maker's examples.
@@ -283,6 +289,27 @@ def _validate_template(
         message = (
             "Template must contain '{suffix}' placeholder "
             "for the file extension."
+        )
+        raise click.BadParameter(message=message, ctx=ctx, param=param)
+
+    # Reject templates that could resolve outside the per-example
+    # isolation directory. The formatted name is joined directly to a
+    # freshly-created directory, so it must be a single safe path
+    # component (a basename): no path separators, parent references, or
+    # absolute paths. Both separator conventions are treated as
+    # separators regardless of the host OS.
+    if (
+        "/" in formatted
+        or "\\" in formatted
+        or PurePosixPath(formatted).is_absolute()
+        or PureWindowsPath(formatted).is_absolute()
+        or ".." in PurePosixPath(formatted).parts
+        or ".." in PureWindowsPath(formatted).parts
+    ):
+        message = (
+            "Template must produce a file name within the temporary "
+            "directory: it may not contain path separators, parent "
+            "references, or absolute paths."
         )
         raise click.BadParameter(message=message, ctx=ctx, param=param)
 

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1267,6 +1267,130 @@ def test_template_malformed_raises_error(
     assert result.output.startswith(expected_prefix)
 
 
+@pytest.mark.parametrize(
+    argnames="template",
+    argvalues=[
+        pytest.param("../victim{suffix}", id="parent-escape"),
+        pytest.param("sub/dir{suffix}", id="path-separator"),
+        pytest.param("/tmp/evil{suffix}", id="absolute-path"),  # noqa: S108
+    ],
+)
+def test_template_escaping_directory_rejected(
+    *,
+    tmp_path: Path,
+    template: str,
+) -> None:
+    """Templates that could resolve outside the temporary directory are
+    rejected.
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--temporary-file-name-template",
+        template,
+        "--command",
+        "echo",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    expected_output = (
+        "Usage: doccmd [OPTIONS] [DOCUMENT_PATHS]...\n"
+        "Try 'doccmd --help' for help.\n"
+        "\n"
+        "Error: Invalid value for '--temporary-file-name-template': "
+        "Template must produce a file name within the temporary "
+        "directory: it may not contain path separators, parent "
+        "references, or absolute paths.\n"
+    )
+    assert result.output == expected_output
+
+
+def test_template_within_directory_accepted(tmp_path: Path) -> None:
+    """A normal template that stays within the temporary directory is
+    accepted and works.
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+            assert x == 4
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--temporary-file-name-template",
+        "{prefix}_{unique}{suffix}",
+        "--command",
+        "echo",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+
+
+def test_template_escape_does_not_delete_sibling(tmp_path: Path) -> None:
+    """A template that escapes the isolation directory is rejected and
+    leaves unrelated sibling files untouched.
+    """
+    runner = CliRunner()
+    source_file = tmp_path / "source.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+        """,
+    )
+    source_file.write_text(data=content, encoding="utf-8")
+    victim_file = tmp_path / "victim.txt"
+    sentinel = "do not delete me"
+    victim_file.write_text(data=sentinel, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--temporary-file-name-template",
+        "../victim{suffix}",
+        "--temporary-file-extension",
+        ".txt",
+        "--command",
+        "true",
+        str(object=source_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert victim_file.exists()
+    assert victim_file.read_text(encoding="utf-8") == sentinel
+
+
 def test_temporary_file_includes_source_name(tmp_path: Path) -> None:
     """The temporary file name includes the sanitized source file name."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary

`--temporary-file-name-template` accepted path separators, parent references (`..`), and absolute paths. The formatted name was joined directly to the freshly-created per-example isolation directory, so a template such as `../victim{suffix}` resolved outside that directory. The shell evaluator then used the escaped path: an existing target was overwritten with the code block and deleted during cleanup, while doccmd exited 0 — silent data loss.

## Changes

- `_validate_template` now rejects, during Click parsing, any template whose formatted result is not a single safe basename (contains `/` or `\`, is absolute under POSIX or Windows rules, or contains a `..` component).
- Defense in depth: `_TempFilePathMaker.__call__` asserts the resolved file stays directly inside the isolation directory.
- Regression tests covering parent-escape, path-separator, and absolute-path templates (all rejected with exit code 2), a positive test that a normal template still works, and an end-to-end test proving a sibling `victim.txt` is untouched.
- Newsfragment `newsfragments/1211.change.rst`.

Full test suite passes at 100% coverage.

Fixes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets file-path handling that could cause data loss; the change is narrow validation plus defense-in-depth with strong test coverage.
> 
> **Overview**
> Closes a path-traversal hole where `--temporary-file-name-template` could format to names with `..`, `/`, `\`, or absolute paths, so temp files were created outside the per-example isolation directory and cleanup could overwrite or delete unrelated files.
> 
> **`_validate_template`** now rejects those templates at CLI parse time (POSIX and Windows rules). **`_TempFilePathMaker`** adds an assert that the resolved path stays directly under the isolation directory. Tests cover rejection cases, a happy path, and that a sibling file is untouched; a newsfragment documents the change for #1211.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a917cec29bfe4216552d4c323f3ac63ed2a66b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->