### PR TITLE
Validate --command instead of crashing on empty/malformed values

### DIFF
--- a/newsfragments/1213.change.rst
+++ b/newsfragments/1213.change.rst
@@ -1,0 +1,1 @@
+Reject an empty or malformed ``--command`` value with a usage error instead of crashing (`#1213 <https://github.com/adamtheturtle/doccmd/issues/1213>`_).

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -320,6 +320,30 @@ def _validate_no_empty_string(
     return value
 
 
+@beartype
+def _validate_command(
+    ctx: click.Context | None,
+    param: click.Parameter | None,
+    value: str,
+) -> str:
+    """Validate that the command is not empty and is well-formed."""
+    try:
+        args = shlex.split(s=value)
+    except ValueError as exc:
+        message = f"Malformed command: {exc}"
+        raise click.BadParameter(
+            message=message,
+            ctx=ctx,
+            param=param,
+        ) from exc
+
+    if not args:
+        message = "The command cannot be empty."
+        raise click.BadParameter(message=message, ctx=ctx, param=param)
+
+    return value
+
+
 _ClickCallback = Callable[[click.Context | None, click.Parameter | None, T], T]
 
 
@@ -1162,6 +1186,7 @@ def _get_sybil(
         "--command",
         type=str,
         required=True,
+        callback=_validate_command,
         help="The command to run against code blocks.",
     ),
 )

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1168,6 +1168,57 @@ def test_invalid_template_placeholder(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    argnames=("command", "expected_message"),
+    argvalues=[
+        pytest.param("", "The command cannot be empty.", id="empty"),
+        pytest.param(
+            "'",
+            "Malformed command: No closing quotation",
+            id="malformed-quoting",
+        ),
+    ],
+)
+def test_invalid_command(
+    *,
+    tmp_path: Path,
+    command: str,
+    expected_message: str,
+) -> None:
+    """An error is raised for an empty or malformed ``--command`` value."""
+    runner = CliRunner()
+    rst_file = tmp_path / "example.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            x = 2 + 2
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--language",
+        "python",
+        "--command",
+        command,
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    expected_output = (
+        "Usage: doccmd [OPTIONS] [DOCUMENT_PATHS]...\n"
+        "Try 'doccmd --help' for help.\n"
+        "\n"
+        "Error: Invalid value for '-c' / '--command': "
+        f"{expected_message}\n"
+    )
+    assert result.output == expected_output
+
+
+@pytest.mark.parametrize(
     argnames="template",
     argvalues=[
         pytest.param("{prefix}_{unique}", id="missing-suffix"),

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -1184,7 +1184,9 @@ def test_invalid_command(
     command: str,
     expected_message: str,
 ) -> None:
-    """An error is raised for an empty or malformed ``--command`` value."""
+    """An error is raised for an empty or malformed ``--command``
+    value.
+    """
     runner = CliRunner()
     rst_file = tmp_path / "example.rst"
     content = textwrap.dedent(


### PR DESCRIPTION
## Summary

The required `--command` option previously accepted an empty string and malformed shell quoting, both producing uncaught tracebacks instead of a Click usage error:

- An empty command (`''`) made `shlex.split` return `[]`, later triggering a secondary `IndexError`.
- Unmatched quoting (e.g. `"'"`) raised an uncaught `ValueError: No closing quotation`.

This adds a `_validate_command` Click callback on the `--command` option that:

- Runs `shlex.split` in a `try`/`except ValueError`, converting failures into a concise `click.BadParameter` ("Malformed command: ...").
- Rejects empty commands with `click.BadParameter` ("The command cannot be empty.").

Both now exit with code 2 and a clean usage error, no traceback.

## Tests

Added a parametrized regression test covering the empty and malformed-quoting cases, asserting the exact Click usage output. Full suite passes with 100% coverage.

Fixes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI input-validation change with targeted tests; no changes to command execution or document processing paths.
> 
> **Overview**
> **`--command` now fails fast with a Click usage error** instead of raising an uncaught traceback when the value is empty or has bad shell quoting.
> 
> A new `_validate_command` callback on the required `-c` / `--command` option runs `shlex.split` during option parsing: `ValueError` becomes `Malformed command: …`, and a split that yields no tokens becomes `The command cannot be empty.` A newsfragment documents the behavior for #1213.
> 
> Regression coverage is a parametrized CLI test that asserts the exact usage output for empty and unmatched-quote inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e316a29df500b54ce1f8d2a772f151129c1fd769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->