### PR TITLE
Support multi-part file extensions

### DIFF
--- a/newsfragments/1212.change.rst
+++ b/newsfragments/1212.change.rst
@@ -1,0 +1,1 @@
+Support configured file extensions with more than one dot (for example ``--rst-extension=.test.rst``) for both direct files and directory discovery (`#1212 <https://github.com/adamtheturtle/doccmd/issues/1212>`_).

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -290,16 +290,44 @@ def _validate_template(
 
 
 @beartype
+def _get_markup_language(
+    *,
+    file_path: Path,
+    suffix_map: Mapping[str, MarkupLanguage],
+) -> MarkupLanguage | None:
+    """Return the markup language for a file based on its configured
+    suffix.
+
+    Matches the file name against configured suffixes (which may contain
+    more than one dot, e.g. ``.test.rst``), preferring the longest match.
+    """
+    file_name = file_path.name
+    matching_suffixes = [
+        suffix
+        for suffix in suffix_map
+        if suffix != "." and file_name.endswith(suffix)
+    ]
+    if not matching_suffixes:
+        return None
+    longest_suffix = max(matching_suffixes, key=len)
+    return suffix_map[longest_suffix]
+
+
+@beartype
 def _validate_given_files_have_known_suffixes(
     *,
     given_files: Iterable[Path],
-    known_suffixes: Iterable[str],
+    suffix_map: Mapping[str, MarkupLanguage],
 ) -> None:
     """Validate that the given files have known suffixes."""
     given_files_unknown_suffix = [
         document_path
         for document_path in given_files
-        if document_path.suffix not in known_suffixes
+        if _get_markup_language(
+            file_path=document_path,
+            suffix_map=suffix_map,
+        )
+        is None
     ]
 
     for given_file_unknown_suffix in given_files_unknown_suffix:
@@ -688,7 +716,11 @@ def _process_file_path(
 ) -> list[_CollectedError]:
     """Process a single documentation file."""
     local_errors: list[_CollectedError] = []
-    markup_language = suffix_map[file_path.suffix]
+    markup_language = _get_markup_language(
+        file_path=file_path,
+        suffix_map=suffix_map,
+    )
+    assert markup_language is not None  # noqa: S101
     encoding = _get_encoding(document_path=file_path)
     if encoding is None:
         could_not_determine_encoding_msg = (
@@ -1736,7 +1768,7 @@ def main(
             for document_path in document_paths
             if document_path.is_file()
         ],
-        known_suffixes=suffix_map.keys(),
+        suffix_map=suffix_map,
     )
 
     file_paths = _get_file_paths(

--- a/tests/test_doccmd.py
+++ b/tests/test_doccmd.py
@@ -3005,6 +3005,86 @@ def test_custom_rst_file_suffixes(tmp_path: Path) -> None:
     assert result.stdout == expected_output
 
 
+def test_multi_part_rst_extension_direct_file(tmp_path: Path) -> None:
+    """A direct file with a multi-dot configured suffix is processed.
+
+    This is a regression test for a bug where a direct file ending in a
+    configured multi-dot suffix (e.g. ``.test.rst``) was rejected with
+    "Markup language not known".
+    """
+    runner = CliRunner()
+    rst_file = tmp_path / "example.test.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            multi_part_block
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--no-pad-file",
+        "--language",
+        "python",
+        "--command",
+        "cat",
+        "--rst-extension",
+        ".test.rst",
+        "--myst-extension",
+        ".",
+        str(object=rst_file),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert "multi_part_block" in result.stdout
+
+
+def test_multi_part_rst_extension_in_directory(tmp_path: Path) -> None:
+    """A multi-dot configured suffix is discovered in a directory.
+
+    This is a regression test for a bug where directory discovery found a
+    file ending in a configured multi-dot suffix (e.g. ``.test.rst``) but
+    then crashed with ``KeyError`` when processing it.
+    """
+    runner = CliRunner()
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    rst_file = docs_dir / "example.test.rst"
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
+
+            multi_part_block
+        """,
+    )
+    rst_file.write_text(data=content, encoding="utf-8")
+    arguments = [
+        "--no-pad-file",
+        "--language",
+        "python",
+        "--command",
+        "cat",
+        "--rst-extension",
+        ".test.rst",
+        "--myst-extension",
+        ".",
+        str(object=tmp_path),
+    ]
+    result = runner.invoke(
+        cli=main,
+        args=arguments,
+        catch_exceptions=False,
+        color=True,
+    )
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert "multi_part_block" in result.stdout
+
+
 def test_markdown_code_block_line_number(tmp_path: Path) -> None:
     """Line numbers in error messages for Markdown code blocks are correct.
 


### PR DESCRIPTION
Fixes #1212.

Configured file extensions with more than one dot (for example ``--rst-extension=.test.rst``) were accepted at parse time but unusable: a direct file was rejected with "Markup language not known", and directory discovery found the file then crashed with ``KeyError`` during processing. Both paths resolved a file's markup language using only ``Path.suffix`` (the final component), which never matched the whole configured multi-dot string.

This adds a single ``_get_markup_language`` helper that matches a file name against the configured suffixes with ``str.endswith``, preferring the longest match (so ``.test.rst`` wins over ``.rst``). It is used both when validating direct files and when processing discovered files, so multi-dot suffixes work consistently. Existing single-suffix behaviour is unchanged.

Regression tests cover both scenarios (direct file and directory discovery) with ``--rst-extension=.test.rst --myst-extension=.``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to suffix-to-markup resolution with longest-match semantics; covered by new regression tests and leaves default single-suffix behavior unchanged.
> 
> **Overview**
> **Fixes multi-dot configured file extensions** (e.g. `--rst-extension=.test.rst`) so they work for direct files and directory discovery.
> 
> Markup language was resolved with `Path.suffix` (only the last segment), so names like `example.test.rst` never matched the configured string. Direct paths failed validation with "Markup language not known"; discovered files could hit a `KeyError` during processing.
> 
> The PR adds **`_get_markup_language`**, which matches `file_path.name` against configured suffixes via `endswith` and picks the **longest** match. That helper replaces `suffix_map[file_path.suffix]` in validation and in `_process_file_path`. Single-segment extensions behave as before.
> 
> Regression tests cover direct file and directory discovery with `--rst-extension=.test.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7685698e856eb9255ca5cff5fd85ff1f6a3bea2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->