### PR TITLE
Bump sybil-extras to 2026.7.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # Pin this dependency as we expect:
     # * It might have breaking changes
     # * It is not a direct dependency of the user
-    "sybil-extras==2026.5.25",
+    "sybil-extras==2026.7.19",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/uv.lock
+++ b/uv.lock
@@ -586,7 +586,7 @@ requires-dist = [
     { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.6.8.post1" },
     { name = "sybil", specifier = ">=9.3.0,<11.0.0" },
-    { name = "sybil-extras", specifier = "==2026.5.25" },
+    { name = "sybil-extras", specifier = "==2026.7.19" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.60" },
@@ -2193,7 +2193,7 @@ wheels = [
 
 [[package]]
 name = "sybil-extras"
-version = "2026.5.25"
+version = "2026.7.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -2201,9 +2201,9 @@ dependencies = [
     { name = "myst-parser" },
     { name = "sybil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/7e/fe6068c73d54469ee10a9f9ee0bdca9d188e745c1e2416dff213a11273ff/sybil_extras-2026.5.25.tar.gz", hash = "sha256:6d96ed90170bd36329b7e4463eb609a500beae4b95bb90b0aade789b893baf25", size = 105629, upload-time = "2026-05-25T09:17:56.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/3c/27b1055b5afb809f055c68ba5858a4a498757f54f90827e16918ce53f39d/sybil_extras-2026.7.19.tar.gz", hash = "sha256:4ee756a2da38287a957bde7edbf295951cdd65407ca4344a1726dfff3c1d64ba", size = 118325, upload-time = "2026-07-19T13:47:44.707Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/16/214e3ba975a56ae401205504a800ff5cb6990f9d0a3b1546f7866367f409/sybil_extras-2026.5.25-py2.py3-none-any.whl", hash = "sha256:42059c87473278f0b83d39d9547f44cc44dbfce3a31e8dd67ec8336263c00657", size = 82291, upload-time = "2026-05-25T09:17:54.516Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1d/d09751fe1bc2d9029c5123ce4c5fb11ead2d09c8f227a8f4658ebe3e7afa/sybil_extras-2026.7.19-py3-none-any.whl", hash = "sha256:794cb004f1f8d2b7e32b7ca1af455972d382053c1c0d03ac2da8c4089616c9fb", size = 89540, upload-time = "2026-07-19T13:47:43.107Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sybil-extras` from `2026.5.25` to `2026.7.19`.

The new release (https://github.com/adamtheturtle/sybil-extras/releases/tag/2026.07.19) moves the reStructuredText literal-block formatting out of the empty-block code writer, fixing:
- adamtheturtle/sybil-extras#1066 — empty fenced blocks with trailing spaces no longer use reST insertion rules
- adamtheturtle/sybil-extras#1111 — reST-specific indent/separator constants removed from empty-block insertion

Updated `pyproject.toml` pin and refreshed `uv.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin and lockfile refresh only; behavior change is localized to sybil-extras document formatting, with no doccmd application logic modified.
> 
> **Overview**
> Updates the pinned **`sybil-extras`** dependency from **`2026.5.25`** to **`2026.7.19`** in `pyproject.toml` and refreshes **`uv.lock`** so installs resolve to the new release.
> 
> The upstream release adjusts how **reStructuredText literal-block** formatting is applied: that logic is no longer tied to the empty fenced-block code writer, which fixes incorrect reST insertion for **empty fenced blocks with trailing spaces** and removes reST-specific indent/separator constants from empty-block insertion paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5915ee2356583827bbf1c33668d315661a3901f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->