### PR TITLE
Use prek action with autofix.ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,37 @@
+---
+name: autofix.ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Run fixers
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage pre-commit --no-fail-fast --verbose
+        env:
+          UV_NO_CACHE: '1'
+          UV_PYTHON: 3.13
+
+      - uses: autofix-ci/action@v1.3.4
+        if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,22 +40,17 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
-          --verbose
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
         env:
+          UV_NO_CACHE: '1'
           UV_PYTHON: ${{ matrix.python-version }}
           # nixfmt is only available on Linux.
           # hadolint is not available on Windows.
           SKIP: ${{ runner.os == 'Windows' && 'nixfmt,hadolint' || '' }}
-
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        # Do not run pre-commit on Windows in order to avoid issues with
-        # line endings.
-        # We only need to run the changes from one runner in any case.
-        if: always()
 
   completion-lint:
     needs: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,51 +6,6 @@ fail_fast: true
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-ci:
-  # We use system Python, with required dependencies specified in pyproject.toml.
-  # We therefore cannot use those dependencies in pre-commit CI.
-  skip:
-    - actionlint
-    - hadolint
-    - check-manifest
-    - deptry
-    - doc8
-    - pydocstringformatter
-    - docs
-    - interrogate
-    - interrogate-docs
-    - linkcheck
-    - nixfmt
-    - mypy
-    - mypy-docs
-    - pylint
-    - pylint-docs
-    - pyproject-fmt-fix
-    - pyright
-    - pyright-docs
-    - pyright-verifytypes
-    - pyroma
-    - ruff-check-fix
-    - ruff-check-fix-docs
-    - ruff-format-fix
-    - ruff-format-fix-docs
-    - shellcheck
-    - shellcheck-docs
-    - shfmt
-    - shfmt-docs
-    - spelling
-    - sphinx-lint
-    - strict-kwargs-fix
-    - ty
-    - ty-docs
-    - pyrefly
-    - pyrefly-docs
-    - uv-lock
-    - vulture
-    - vulture-docs
-    - yamlfix
-    - zizmor
-
 default_install_hook_types: [pre-commit, pre-push]
 
 repos:


### PR DESCRIPTION
## Summary

- run the existing lint jobs with `j178/prek-action@v3.0.0` and prek 0.4.11
- add a dedicated autofix.ci producer workflow using `autofix-ci/action@v1.3.4`
- remove legacy pre-commit.ci Lite configuration where present
- let Dependabot update hook revisions through its `pre-commit` ecosystem

Both actions use exact release tags rather than commit SHAs, following the agreed rollout policy.

## Validation

- all changed YAML parses successfully
- `actionlint` passes for both changed workflows
- `zizmor` reports no findings for both changed workflows

Part of [adamtheturtle/Coding-Project-TODOs#8](https://github.com/adamtheturtle/Coding-Project-TODOs/issues/8).

## Before merge

- [ ] Install the autofix.ci GitHub App for this repository
- [ ] Confirm autofix commits are produced on a test pull request
- [ ] Remove the pre-commit.ci GitHub App after the replacement is verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/workflow and Dependabot configuration; no application runtime or security-sensitive code paths are modified, though autofix.ci requires installing its GitHub App before fixes land on PRs.
> 
> **Overview**
> Replaces the manual **`uv run prek`** lint step and **pre-commit.ci Lite** with **`j178/prek-action`** (prek **0.4.11**) in **`lint.yml`**, and adds a dedicated **`autofix.yml`** workflow that runs pre-commit-stage fixers with **`--no-fail-fast`** then publishes fixes via **`autofix-ci/action`**.
> 
> **Dependabot** gains a **`pre-commit`** ecosystem entry so hook **`rev`** pins can be bumped automatically. The large **`ci:` / `skip:`** block is removed from **`.pre-commit-config.yaml`** because hosted pre-commit.ci is no longer the CI path for those hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956ae43bf32eac9a7f6757f376b316b489acbf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->