### PR TITLE
Remove the last default instead of suppressing it

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -739,7 +739,7 @@ def _handle_error(
     message: str,
     exit_code: int,
     continue_on_error: bool,
-    exc: Exception | None = None,  # noqa: NOD001
+    exc: Exception | None,
 ) -> _CollectedError:
     """Handle an error by either returning it or raising a fatal error."""
     if continue_on_error:
@@ -793,6 +793,7 @@ def _process_file_path(
                     message=could_not_determine_encoding_msg,
                     exit_code=1,
                     continue_on_error=continue_on_error,
+                    exc=None,
                 )
             )
         return local_errors


### PR DESCRIPTION
Removes the repository's only remaining `NOD001` suppression by removing the default for real.

`_handle_error` is module-private, so requiring `exc` is not an API change. Of its seven call sites, six already passed `exc` explicitly; the one that relied on the default now passes `exc=None`.

**1 → 0.** ruff clean, 176 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal helper signature tightening with explicit `exc=None` at one call site; no user-facing API or error-handling logic changes.
> 
> **Overview**
> Makes **`exc`** a required keyword argument on module-private **`_handle_error`** by dropping its default and removing the **`NOD001`** noqa that had suppressed that rule.
> 
> The only call site that previously relied on the default now passes **`exc=None`** when encoding cannot be determined (no underlying exception). Fatal error chaining behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7a087c1850bc3beb596c34a2825e5f04952276e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->