### PR TITLE
Configure mypy to respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,6 +412,7 @@ max_supported_python = "3.14"
 [tool.mypy]
 files = [ "." ]
 exclude = [ "build" ]
+exclude_gitignore = true
 follow_untyped_imports = true
 strict = true
 plugins = [


### PR DESCRIPTION
## Summary

- configure mypy with `exclude_gitignore = true`
- prevent files ignored by Git from being included in mypy discovery

## Impact

Mypy will respect the project's `.gitignore` rules when discovering files. This avoids type-checking generated, local, or otherwise ignored files.

## Validation

- formatted and parsed `pyproject.toml` with `pyproject-fmt`
- verified the branch diff is exactly one added line in `pyproject.toml`
- ran Git whitespace validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line developer tooling config change with no runtime, security, or product behavior impact.
> 
> **Overview**
> Configures mypy with `exclude_gitignore = true` so type-checking skips files ignored by Git (generated, local, or otherwise excluded paths) instead of only the existing `build` exclude.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93dfd498245e743a9c8691eb7b77f720886bfe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->