### PR TITLE
Bump August dependency releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # Pin this dependency as we expect:
     # * It might have breaking changes
     # * It is not a direct dependency of the user
-    "sybil-extras==2026.7.19",
+    "sybil-extras==2026.8.16",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -1146,6 +1146,7 @@ def _get_sybil(
         code_block_parsers = [
             markup_language.code_block_parser_cls(
                 language=code_block_language,
+                evaluator=None,
             )
             for code_block_language in code_block_languages
         ]
@@ -1178,6 +1179,7 @@ def _get_sybil(
             )
             code_block_parser = markup_language.code_block_parser_cls(
                 language=code_block_language,
+                evaluator=None,
             )
             mdx_attribute_grouped_parsers.append(
                 MdxAttributeGroupedSourceParser(

--- a/uv.lock
+++ b/uv.lock
@@ -662,7 +662,7 @@ requires-dist = [
     { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.16" },
     { name = "sybil", specifier = ">=9.3.0,<11.0.0" },
-    { name = "sybil-extras", specifier = "==2026.7.19" },
+    { name = "sybil-extras", specifier = "==2026.8.16" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.72" },
@@ -2289,7 +2289,7 @@ wheels = [
 
 [[package]]
 name = "sybil-extras"
-version = "2026.7.19"
+version = "2026.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -2297,9 +2297,9 @@ dependencies = [
     { name = "myst-parser" },
     { name = "sybil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/3c/27b1055b5afb809f055c68ba5858a4a498757f54f90827e16918ce53f39d/sybil_extras-2026.7.19.tar.gz", hash = "sha256:4ee756a2da38287a957bde7edbf295951cdd65407ca4344a1726dfff3c1d64ba", size = 118325, upload-time = "2026-07-19T13:47:44.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/15/2a3b048a6d12e03641b5ce5df69eac13aa3b579542354adca78c0db66480/sybil_extras-2026.8.16.tar.gz", hash = "sha256:79c8dda5d2261b93d7885edbdfb534a0b6ebf3c4f8c8a53d400734a556fd402d", size = 119266, upload-time = "2026-08-16T09:17:42.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/1d/d09751fe1bc2d9029c5123ce4c5fb11ead2d09c8f227a8f4658ebe3e7afa/sybil_extras-2026.7.19-py3-none-any.whl", hash = "sha256:794cb004f1f8d2b7e32b7ca1af455972d382053c1c0d03ac2da8c4089616c9fb", size = 89540, upload-time = "2026-07-19T13:47:43.107Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fb/8f1ebdd721b12be7f1428f820c983f3cbe3ef3e39d9d78240db1b260e3bd/sybil_extras-2026.8.16-py3-none-any.whl", hash = "sha256:9dd08d8a2b24c643170f88bc4d9c15464fc4a3c2829d844d68c1f3f76c3597ce", size = 87648, upload-time = "2026-08-16T09:17:41.183Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates sybil-extras to its August 2026 release.\n\nValidation: `uv lock` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Sybil parser wiring for grouped execution paths; behavior should be unchanged but depends on the new sybil-extras API contract.
> 
> **Overview**
> Pins **sybil-extras** from `2026.7.19` to `2026.8.16` in `pyproject.toml` and refreshes `uv.lock`.
> 
> Adapts `_get_sybil` so `code_block_parser_cls` is constructed with **`evaluator=None`** when blocks are not evaluated directly on the parser—specifically for **`--group-file`** (evaluation via `group_all_parser_cls`) and **`--group-mdx-by-attribute`** (evaluation via `MdxAttributeGroupedSourceParser` with `ungrouped_evaluator` / group evaluators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5015805dba4311e40606270b4907603ffdd521c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->