### PR TITLE
Bump mypy-strict-kwargs to 2026.8.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ optional-dependencies.dev = [
     "hadolint-bin==2.15.1; sys_platform!='win32'",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.25",
+    "mypy-strict-kwargs==2026.8.25.1",
     "no-defaults==2.1.0",
     "prek==0.4.14",
     "pydocstringformatter==1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ optional-dependencies.dev = [
     "hadolint-bin==2.15.1; sys_platform!='win32'",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.20.1",
+    "mypy-strict-kwargs==2026.8.25",
     "no-defaults==2.1.0",
     "prek==0.4.14",
     "pydocstringformatter==1.0.0",
@@ -480,12 +480,12 @@ type = [
 # `relative_to` and `is_relative_to` have `other` parameter that is
 # positional-only on Python 3.14+.
 # We need to support older versions, so we ignore them.
-# ``@beartype`` / ``@cloup.option_group`` apply with one positional argument;
-# the plugin resolves those callables to these internal names.
+# ``@cloup.option_group("...", opt, opt)`` passes the option group's name
+# and its options positionally; the plugin resolves that callable to this
+# internal name.
 ignore_names = [
     "pathlib.Path.is_relative_to",
     "pathlib.Path.relative_to",
-    "beartype._decor.decorcache.beartype",
     "cloup._option_groups.option_group",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ requires-dist = [
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.1" },
-    { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.25" },
+    { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.25.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.14" },
     { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==1.0.0" },
@@ -1155,14 +1155,14 @@ wheels = [
 
 [[package]]
 name = "mypy-strict-kwargs"
-version = "2026.8.25"
+version = "2026.8.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/d7/4abbb7f635d60797741f49519d0145b642c78b5ce99dbcdd7adc590a7004/mypy_strict_kwargs-2026.8.25.tar.gz", hash = "sha256:b755720b0f721605b8d5d7569a25908d34c4fb9df29d2f83b80006c7eaec3c88", size = 56086, upload-time = "2026-08-25T05:54:58.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/f4/dde18a0a2289aaef098a46a0b31b4c552b7d1e2db09032c87237118f9561/mypy_strict_kwargs-2026.8.25.1.tar.gz", hash = "sha256:f65e1d4ee9557dd1392d9bcb13fb8e2fbd925e04d145a8c8a3571e0aa67ab009", size = 56656, upload-time = "2026-08-25T06:36:04.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/b5/bcc2a9a3b648039f38808b86232e14864201b15292bea5d6cb4574da3b4c/mypy_strict_kwargs-2026.8.25-py3-none-any.whl", hash = "sha256:5054921b3b693ed40833cb70756e824b2bdd4e0143ec2c01f0879b4c5fae3ce5", size = 26906, upload-time = "2026-08-25T05:54:57.227Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5e/411eebd9e9871700edc0f16b8cd7e22b167ea5f95c39556627c651832db4/mypy_strict_kwargs-2026.8.25.1-py3-none-any.whl", hash = "sha256:94d73bce6157737835f8e5b04ff72916dbc554f243b9192b006603e8ba3e326b", size = 27286, upload-time = "2026-08-25T06:36:02.865Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -631,7 +631,7 @@ requires-dist = [
     { name = "homebrew-pypi-poet", marker = "extra == 'release'", specifier = "==0.10" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.1" },
-    { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.20.1" },
+    { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.25" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.14" },
     { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==1.0.0" },
@@ -1155,14 +1155,14 @@ wheels = [
 
 [[package]]
 name = "mypy-strict-kwargs"
-version = "2026.8.20.1"
+version = "2026.8.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/4e/0a584a317545a9526fd53786962a6c516252b5721823325275c40ae5a6a5/mypy_strict_kwargs-2026.8.20.1.tar.gz", hash = "sha256:7daed333ce8dd5d8980091d46e1354e5ea52870d403d4a70b69ca684e9aadba7", size = 55546, upload-time = "2026-08-20T11:06:56.866Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/d7/4abbb7f635d60797741f49519d0145b642c78b5ce99dbcdd7adc590a7004/mypy_strict_kwargs-2026.8.25.tar.gz", hash = "sha256:b755720b0f721605b8d5d7569a25908d34c4fb9df29d2f83b80006c7eaec3c88", size = 56086, upload-time = "2026-08-25T05:54:58.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/41/31497135553443385038302f4eb7bfc43cc3feca7c44a32c181383cf2b75/mypy_strict_kwargs-2026.8.20.1-py3-none-any.whl", hash = "sha256:8f91bd5830e717a4cf8f591c7dceb25b870d63448b073364a9092f4ed56a4eda", size = 26538, upload-time = "2026-08-20T11:06:55.395Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b5/bcc2a9a3b648039f38808b86232e14864201b15292bea5d6cb4574da3b4c/mypy_strict_kwargs-2026.8.25-py3-none-any.whl", hash = "sha256:5054921b3b693ed40833cb70756e824b2bdd4e0143ec2c01f0879b4c5fae3ce5", size = 26906, upload-time = "2026-08-25T05:54:57.227Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`mypy-strict-kwargs` 2026.08.20.1 shipped two regressions, fixed in
2026.8.25 by https://github.com/adamtheturtle/mypy-strict-kwargs/pull/796:

- Its `get_attribute_hook` claimed every attribute name and so shadowed
  mypy's own default-plugin hooks, which is what gives `SomeEnum.value`
  its real type; every enum `.value` access degraded to `Any`.
- The new overloaded-call `call-arg` check reported decorator
  applications such as `@beartype`, which have no keyword form.

This bumps the pin and drops the `ignore_names` opt-outs that were added
for the second regression. Verified locally: mypy is clean without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACFJDTrtojHAEbXRGoxAg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only tooling pin and mypy plugin configuration; no runtime or production code changes.
> 
> **Overview**
> Upgrades the dev dependency **mypy-strict-kwargs** from `2026.8.20.1` to `2026.8.25.1` (with matching **uv.lock** updates) to pick up fixes for two regressions in the previous release.
> 
> With the fixed plugin, **`beartype._decor.decorcache.beartype`** is removed from `[tool.mypy_strict_kwargs].ignore_names`—that entry was only needed when the plugin incorrectly flagged `@beartype` decorator applications. Comments for the remaining **cloup** `option_group` ignore are clarified; **pathlib** `relative_to` / `is_relative_to` ignores stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc557a84b6b978235a186ec36b87b6479c8d31a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->