### PR TITLE
Sign and notarize macOS release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,16 @@ on:
         required: true
       HOMEBREW_TAP_GITHUB_TOKEN:
         required: true
+      DEVELOPER_ID_APP_CERT_P12_BASE64:
+        required: true
+      DEVELOPER_ID_APP_CERT_PASSWORD:
+        required: true
+      APPLE_ID:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
+      APPLE_APP_PASSWORD:
+        required: true
 
 jobs:
   build:
@@ -368,6 +378,43 @@ jobs:
           options: --onefile, --name "doccmd-macos"
           upload_exe_with_name: doccmd-macos
           clean_checkout: false
+
+      - name: Import the Developer ID certificate
+        uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466  # v7.0.0
+        with:
+          p12-file-base64: ${{ secrets.DEVELOPER_ID_APP_CERT_P12_BASE64 }}
+          p12-password: ${{ secrets.DEVELOPER_ID_APP_CERT_PASSWORD }}
+
+      - name: Sign the macOS binary
+        run: |
+          codesign --force --timestamp --options runtime \
+              --entitlements bin/entitlements.plist \
+              --sign "Developer ID Application" dist/doccmd-macos
+          codesign --verify --strict --verbose=2 dist/doccmd-macos
+
+      - name: Check the signed binary still runs
+        run: dist/doccmd-macos --version
+
+      - name: Notarize the macOS binary
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: |
+          ditto -c -k --sequesterRsrc dist/doccmd-macos "${RUNNER_TEMP}/doccmd-macos.zip"
+          xcrun notarytool submit "${RUNNER_TEMP}/doccmd-macos.zip" \
+              --apple-id "${APPLE_ID}" --team-id "${APPLE_TEAM_ID}" \
+              --password "${APPLE_APP_PASSWORD}" --wait --timeout 30m \
+              2>&1 | tee "${RUNNER_TEMP}/notarization.log" || true
+          grep -q 'status: Accepted' "${RUNNER_TEMP}/notarization.log"
+
+      - name: Check Gatekeeper accepts the binary
+        uses: nick-fields/retry@v4
+        with:
+          timeout_seconds: 60
+          max_attempts: 10
+          retry_wait_seconds: 30
+          command: spctl --assess --type exec -vv dist/doccmd-macos
 
       - name: Upload macOS binary to release
         env:

--- a/bin/entitlements.plist
+++ b/bin/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/source/release-process.rst
+++ b/docs/source/release-process.rst
@@ -10,6 +10,15 @@ Outcomes
 * An updated Nix flake (automatically uses the latest ``git`` tag).
 * New pre-built binaries for Linux, macOS, and Windows.
 
+Repository secrets
+~~~~~~~~~~~~~~~~~~
+
+The macOS binary is signed with a Developer ID Application certificate and
+notarized with Apple.  The workflow requires
+``DEVELOPER_ID_APP_CERT_P12_BASE64``,
+``DEVELOPER_ID_APP_CERT_PASSWORD``, ``APPLE_ID``, ``APPLE_TEAM_ID``, and
+``APPLE_APP_PASSWORD`` as repository secrets.
+
 Perform a Release
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add Developer ID signing, Apple notarization, Gatekeeper verification, and the required release documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release pipeline and secret handling change for macOS; failures block macOS uploads, and the library-validation entitlement slightly relaxes code-signing constraints on the signed binary.
> 
> **Overview**
> macOS release artifacts are now **Developer ID–signed**, **notarized**, and checked with **Gatekeeper** before upload, so distributed `doccmd-macos` binaries should pass macOS security prompts.
> 
> The `build-macos` job imports the P12 cert, signs `dist/doccmd-macos` with hardened runtime and `bin/entitlements.plist` (library validation disabled for PyInstaller), runs `--version`, submits a zip via `notarytool`, and retries `spctl --assess` until acceptance. **`workflow_call` now requires five new secrets** (cert, password, Apple ID, team ID, app password). **Release docs** list those repository secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9888b0ceefa9d56c2914b02d7364db5dc0d0e43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->