### PR TITLE
Remove inapplicable Gatekeeper check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,14 +408,6 @@ jobs:
               2>&1 | tee "${RUNNER_TEMP}/notarization.log" || true
           grep -q 'status: Accepted' "${RUNNER_TEMP}/notarization.log"
 
-      - name: Check Gatekeeper accepts the binary
-        uses: nick-fields/retry@v4
-        with:
-          timeout_seconds: 60
-          max_attempts: 10
-          retry_wait_seconds: 30
-          command: spctl --assess --type exec -vv dist/doccmd-macos
-
       - name: Upload macOS binary to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,11 @@ html_theme_options = {
 
 # Retry link checking to avoid transient network errors.
 linkcheck_retries = 5
+linkcheck_ignore = [
+    # This site intermittently aborts secure connections from GitHub's
+    # Windows runners even after all configured retries.
+    r"https://wiki\.nixos\.org/wiki/Flakes.*",
+]
 
 spelling_word_list_filename = "../../spelling_private_dict.txt"
 


### PR DESCRIPTION
Apple notarization accepts the signed command-line executable, but spctl refuses to assess bare executables because they are not app bundles. Keep codesign verification, startup testing, and Apple notarization; remove only the inapplicable app-bundle assessment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect release workflow steps and documentation link-check configuration, not runtime product behavior.
> 
> **Overview**
> **macOS release:** Removes the post-notarization **Gatekeeper** check that retried `spctl --assess --type exec` on `dist/doccmd-macos`. That step targeted app-bundle assessment and was failing for a bare CLI binary even when Apple notarization succeeded. **Codesign**, **codesign --verify**, the **`--version` smoke test**, and **notarytool** submission with an Accepted-status grep are unchanged.
> 
> **Docs CI:** Adds a Sphinx **`linkcheck_ignore`** regex for `https://wiki.nixos.org/wiki/Flakes.*` so link checking does not fail on intermittent TLS aborts from GitHub Windows runners after retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe2a088eed280ac63a6fe7bfaae6d636f796e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->