### PR TITLE
Document Click 8.5 support

### DIFF
--- a/newsfragments/2539.change
+++ b/newsfragments/2539.change
@@ -1,0 +1,1 @@
+Support Click 8.5.


### PR DESCRIPTION
Add the release fragment for the already-merged Click 8.5 compatibility update so a compatible doccmd release can be published.

This unblocks VWS-Python/vws-cli#2539.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog fragment only; no runtime, dependency, or application logic changes in this PR.
> 
> **Overview**
> Adds a **towncrier/newsfragment** entry (`newsfragments/2539.change`) so the next release notes will record **Click 8.5** compatibility.
> 
> This is changelog-only; it documents support that was already landed elsewhere and enables cutting a **doccmd** release that unblocks downstream work (e.g. VWS-Python/vws-cli#2539).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2567e06afa8622bbfd5763b6d14661429ecb64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->