### PR TITLE
Finish porting the signed macOS release from literalizer-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,15 @@ jobs:
           upload_exe_with_name: doccmd-macos
           clean_checkout: false
 
+      # PyInstaller ad-hoc signs the binary, which is enough to run it
+      # locally but not enough for Gatekeeper, which blocks anything
+      # carrying ``com.apple.quarantine`` - the attribute a browser sets on
+      # a downloaded file.  A Developer ID signature plus notarization
+      # clears that.
+      #
+      # This action deletes its temporary keychain in a post step, so no
+      # cleanup step is needed.  It is pinned to a commit rather than a tag
+      # because it handles the certificate and its password.
       - name: Import the Developer ID certificate
         uses: Apple-Actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466  # v7.0.0
         with:
@@ -387,26 +396,70 @@ jobs:
 
       - name: Sign the macOS binary
         run: |
-          codesign --force --timestamp --options runtime \
+          # ``--sign`` takes a name prefix, and matches the one Developer ID
+          # identity in the keychain the previous step added to the search
+          # list.  It fails with "ambiguous" if more than one matches, so
+          # this needs no lookup.  There is deliberately no ``--keychain``:
+          # that flag silently falls back to the search list when it cannot
+          # resolve what it is given, so it constrains nothing.
+          #
+          # A secure timestamp and the hardened runtime are both
+          # prerequisites for notarization.  The hardened runtime needs the
+          # entitlements file to leave a ``--onefile`` binary runnable; see
+          # the comments in that file.
+          codesign \
+              --force \
+              --timestamp \
+              --options runtime \
               --entitlements bin/entitlements.plist \
-              --sign "Developer ID Application" dist/doccmd-macos
+              --sign "Developer ID Application" \
+              dist/doccmd-macos
           codesign --verify --strict --verbose=2 dist/doccmd-macos
 
+      # Signing a ``--onefile`` binary with the hardened runtime can leave
+      # it unable to load its own bundled libraries, and nothing before
+      # this point would notice.  Starting up is the whole test: the
+      # bootloader unpacks and loads every bundled library before any
+      # command runs.
       - name: Check the signed binary still runs
         run: dist/doccmd-macos --version
 
+      # A notarization ticket cannot be stapled to a bare Mach-O
+      # executable - ``stapler`` handles only ``.app`` bundles, ``.dmg``,
+      # ``.pkg`` and kexts - so Gatekeeper verifies this binary online.
+      # Shipping a ``.pkg`` instead would allow stapling, at the cost of
+      # the documented ``curl ... && chmod +x`` one-liner.
+      #
+      # There is no ``spctl --assess`` step: it rejects every bare
+      # executable with "does not seem to be an app", notarized or not.
       - name: Notarize the macOS binary
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: |
+          : "${APPLE_ID:?see docs/source/release-process.rst}" "${APPLE_TEAM_ID:?see docs/source/release-process.rst}" "${APPLE_APP_PASSWORD:?see docs/source/release-process.rst}"
+          # ``notarytool`` takes an archive, not a bare executable.
+          # ``--sequesterRsrc`` keeps extended attributes out of the archive
+          # as stray ``._`` entries, which is what Apple documents for
+          # notarization archives.
           ditto -c -k --sequesterRsrc dist/doccmd-macos "${RUNNER_TEMP}/doccmd-macos.zip"
           xcrun notarytool submit "${RUNNER_TEMP}/doccmd-macos.zip" \
-              --apple-id "${APPLE_ID}" --team-id "${APPLE_TEAM_ID}" \
-              --password "${APPLE_APP_PASSWORD}" --wait --timeout 30m \
-              2>&1 | tee "${RUNNER_TEMP}/notarization.log" || true
-          grep -q 'status: Accepted' "${RUNNER_TEMP}/notarization.log"
+              --apple-id "${APPLE_ID}" \
+              --team-id "${APPLE_TEAM_ID}" \
+              --password "${APPLE_APP_PASSWORD}" \
+              --wait \
+              --timeout 30m 2>&1 | tee "${RUNNER_TEMP}/notarization.log" || true
+          # ``notarytool`` does not reliably exit non-zero on a rejected
+          # submission, so check the reported status.  Only the log says why
+          # a submission was rejected; the submission output does not.
+          if ! grep -q 'status: Accepted' "${RUNNER_TEMP}/notarization.log"; then
+              xcrun notarytool log "$(awk '/^[[:space:]]*id:/ { print $2; exit }' "${RUNNER_TEMP}/notarization.log")" \
+                  --apple-id "${APPLE_ID}" \
+                  --team-id "${APPLE_TEAM_ID}" \
+                  --password "${APPLE_APP_PASSWORD}" || true
+              exit 1
+          fi
 
       - name: Upload macOS binary to release
         env:

--- a/README.rst
+++ b/README.rst
@@ -62,20 +62,6 @@ Pre-built macOS (ARM) binaries
    $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2026.09.01/doccmd-macos -o /usr/local/bin/doccmd &&
        chmod +x /usr/local/bin/doccmd
 
-Pre-built macOS (ARM) binaries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: console
-
-   $ curl --fail -L https://github.com/adamtheturtle/doccmd/releases/download/2026.09.01/doccmd-macos -o /usr/local/bin/doccmd &&
-       chmod +x /usr/local/bin/doccmd
-
-You may need to remove the quarantine attribute to run the binary:
-
-.. code-block:: console
-
-   $ xattr -d com.apple.quarantine /usr/local/bin/doccmd
-
 Pre-built Windows binaries
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/release-process.rst
+++ b/docs/source/release-process.rst
@@ -13,11 +13,33 @@ Outcomes
 Repository secrets
 ~~~~~~~~~~~~~~~~~~
 
-The macOS binary is signed with a Developer ID Application certificate and
-notarized with Apple.  The workflow requires
-``DEVELOPER_ID_APP_CERT_P12_BASE64``,
-``DEVELOPER_ID_APP_CERT_PASSWORD``, ``APPLE_ID``, ``APPLE_TEAM_ID``, and
-``APPLE_APP_PASSWORD`` as repository secrets.
+The release workflow signs and notarizes the macOS binary, which needs five repository secrets.
+Setting them is a one-off, repeated when the signing certificate expires.
+Binaries signed and notarized before an expiry keep working afterwards, because ``--timestamp`` records that the signature was made while the certificate was valid; only new signatures need a renewed certificate.
+
+Signing certificate
+^^^^^^^^^^^^^^^^^^^
+
+``DEVELOPER_ID_APP_CERT_P12_BASE64`` is a ``base64`` encoded PKCS#12 export of a Developer ID Application certificate and its private key.
+The export must contain exactly one such identity: the workflow stops rather than guess which one to sign with.
+``DEVELOPER_ID_APP_CERT_PASSWORD`` is the password that the export is encrypted with.
+
+.. code-block:: console
+
+   $ base64 -i certificate.p12 | gh secret set DEVELOPER_ID_APP_CERT_P12_BASE64
+   $ gh secret set DEVELOPER_ID_APP_CERT_PASSWORD
+
+Notarization credentials
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``notarytool`` authenticates with the Apple ID belonging to the same team as the signing certificate.
+Create an app-specific password at `account.apple.com <https://account.apple.com/>`_.
+
+.. code-block:: console
+
+   $ gh secret set APPLE_ID
+   $ gh secret set APPLE_TEAM_ID
+   $ gh secret set APPLE_APP_PASSWORD
 
 Perform a Release
 ~~~~~~~~~~~~~~~~~

--- a/newsfragments/+sign-notarize-macos-binary.change.rst
+++ b/newsfragments/+sign-notarize-macos-binary.change.rst
@@ -1,0 +1,3 @@
+Sign the macOS binary with a Developer ID certificate and notarize it, so
+Gatekeeper no longer blocks it when it is downloaded in a browser.  The
+``xattr -d com.apple.quarantine`` workaround is no longer needed.


### PR DESCRIPTION
Closes #1351.

The signing and notarization steps already landed on main and the 2026.09.01 release shipped a notarized `doccmd-macos`. This ports the rest of adamtheturtle/literalizer-cli#611: the explanatory comments on each `build-macos` step, a guard that fails early when a notarization secret is missing, a `notarytool log` call that reports why a submission was rejected, and the fuller "Repository secrets" section in the release process docs. It also removes the README's `xattr -d com.apple.quarantine` workaround, which is no longer needed, along with a duplicated "Pre-built macOS (ARM) binaries" section, and adds the news fragment the earlier commits lacked. There is no `spctl --assess` step because it rejects every bare executable with "does not seem to be an app", notarized or not; I verified the released binary runs with a quarantine attribute applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI comments, notarization error reporting, and documentation; no application runtime or security logic changes.
> 
> **Overview**
> Completes the macOS release signing/notarization port from literalizer-cli: mostly **workflow comments and failure handling**, plus user-facing doc cleanup.
> 
> The **`build-macos` job** in `release.yml` now documents why Developer ID signing and notarization are needed (Gatekeeper/quarantine), how `codesign` identity selection works, why a post-sign `--version` smoke test matters for hardened-runtime PyInstaller builds, and why bare Mach-O releases skip stapling/`spctl --assess`. Notarization **fails fast** when `APPLE_ID`, `APPLE_TEAM_ID`, or `APPLE_APP_PASSWORD` are unset, and on rejection it runs **`notarytool log`** before exiting instead of relying only on a grep of the submit output.
> 
> **`README.rst`** drops the duplicate macOS install section and the **`xattr -d com.apple.quarantine`** workaround. **`release-process.rst`** expands the five required GitHub secrets with setup steps for the PKCS#12 export and Apple notarization credentials. A **towncrier fragment** records that notarized macOS binaries no longer need the quarantine workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bd5a456526259dff98816a13994d8aaa1e33a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->