### PR TITLE
Use uv for Dependabot Python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,17 +2,14 @@
 version: 2
 
 updates:
-  - package-ecosystem: pip
+  # Keep ``pyproject.toml`` and ``uv.lock`` updates in one Dependabot commit so
+  # Dependabot can continue rebasing its branches after another update merges.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-  - package-ecosystem: uv
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
## Summary

- use Dependabot's native uv ecosystem for Python dependency updates
- keep pyproject.toml and uv.lock changes in Dependabot's own commit
- retain automatic rebasing after other dependency updates merge

## Validation

- uv lock --check
- uv run --extra dev yamlfix --check .github/dependabot.yml
- Dependabot configuration schema validation
- git diff --check