### PR TITLE
Use the pyrefly strict preset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,6 +425,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+errors.unused-ignore = "error"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     # * It might have breaking changes
     # * It is not a direct dependency of the user
     "sybil-extras==2026.8.16",
+    "typing-extensions>=4.12.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
@@ -425,7 +426,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-errors.unused-ignore = "error"
+preset = "strict"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -16,7 +16,7 @@ from enum import Enum, auto, unique
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from threading import Lock
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 from uuid import uuid4
 
 import charset_normalizer
@@ -63,6 +63,10 @@ from sybil_extras.languages import (
 from sybil_extras.parsers.mdx.attribute_grouped_source import (
     AttributeGroupedSourceParser as MdxAttributeGroupedSourceParser,
 )
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from sybil.typing import Parser
 
 try:
     __version__ = version(distribution_name=__name__)
@@ -688,6 +692,7 @@ class _GroupModifiedError(Exception):
         self._example = example
         self._modified_example_content = modified_example_content
 
+    @override
     def __str__(self) -> str:
         """Get the string representation of the error."""
         unified_diff = difflib.unified_diff(
@@ -1141,6 +1146,8 @@ def _get_sybil(
     ]
 
     mdx_attribute_grouped_parsers: list[MdxAttributeGroupedSourceParser] = []
+    code_block_parsers: list[Parser]
+    group_all_parsers: list[Parser]
 
     if group_file:
         code_block_parsers = [
@@ -1847,7 +1854,7 @@ def main(
         respect_gitignore=respect_gitignore,
     )
 
-    log_command_evaluators = []
+    log_command_evaluators: list[_LogCommandEvaluator] = []
     if verbose:
         _log_info(
             message="Using PTY for running commands."

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,7 @@ dependencies = [
     { name = "pygments" },
     { name = "sybil" },
     { name = "sybil-extras" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -664,6 +665,7 @@ requires-dist = [
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.78" },
     { name = "types-pygments", marker = "extra == 'dev'", specifier = "==2.21.0.20260819" },
+    { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "vale", marker = "extra == 'dev'", specifier = "==3.20.0.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },


### PR DESCRIPTION
Switches the pyrefly config to `preset = "strict"` (see https://pyrefly.org/en/docs/configuration/). Strict enables `unused-ignore`, so stale `# pyrefly: ignore` comments fail the check, along with `implicit-any`, `missing-override-decorator` and others. Any new errors from the stricter checks are fixed in this PR. Same change as VWS-Python/vws-python-mock#3567.

This project supports Python versions before 3.12, where \`typing.override\` does not exist, so \`typing-extensions\` is added as a runtime dependency to provide the \`@override\` decorator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)