### PR TITLE
Use Ty's strictest recommended configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ line-length = 79
 lint.select = [
     "ALL",
 ]
+lint.extend-select = [ "ANN", "PGH003", "PYI" ]
 lint.ignore = [
     # We can manage our own complexity.
     "C901",
@@ -158,6 +159,7 @@ lint.ignore = [
     "PLR0913",
     "PLR0915",
 ]
+lint.explicit-preview-rules = true
 lint.per-file-ignores."doccmd_*.py" = [
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
@@ -182,6 +184,7 @@ lint.flake8-tidy-imports.banned-api."typing.cast".msg = """\
     typing.cast is banned: use explicit type narrowing or a typed variable instead.\
     """
 lint.pydocstyle.convention = "google"
+lint.preview = true
 
 [tool.pylint]
 # Disable the message, report, category or checker with the given id(s). You
@@ -429,10 +432,23 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 
 [tool.ty]
+rules.blanket-ignore-comment = "error"
+rules.division-by-zero = "warn"
+rules.dynamic-function-decorator-return = "error"
+rules.missing-type-argument = "error"
+rules.possibly-missing-attribute = "warn"
+rules.possibly-missing-import = "warn"
+rules.possibly-unresolved-reference = "warn"
+rules.unsound-assignment = "error"
+rules.unsound-return-statement = "error"
+rules.unsound-yield = "error"
+rules.unsupported-dynamic-base = "warn"
 # Error if ty emits any warning-level diagnostics.
 terminal.error-on-warning = true
 # Disable support for `type: ignore` comments
 analysis.respect-type-ignore-comments = false
+analysis.strict-equality-semantics = true
+analysis.strict-generic-narrowing = true
 
 [tool.pytest]
 log_cli = true

--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -554,7 +554,7 @@ class _UsePty(Enum):
     def use_pty(self) -> bool:
         """Whether to use a pseudo-terminal."""
         if self is _UsePty.DETECT:
-            return sys.stdout.isatty() and platform.system() != "Windows"
+            return bool(sys.stdout.isatty()) and platform.system() != "Windows"
         return {
             _UsePty.YES: True,
             _UsePty.NO: False,
@@ -613,22 +613,22 @@ def _map_languages_to_suffix() -> dict[str, str]:
 @beartype
 def _get_group_directives(markers: Iterable[str]) -> Sequence[str]:
     """Group directives based on the provided markers."""
-    directives: Sequence[str] = []
+    directives: list[str] = []
 
     for marker in markers:
         directive = rf"group doccmd[{marker}]"
-        directives = [*directives, directive]
+        directives.append(directive)
     return directives
 
 
 @beartype
 def _get_skip_directives(markers: Iterable[str]) -> Iterable[str]:
     """Skip directives based on the provided markers."""
-    directives: Sequence[str] = []
+    directives: list[str] = []
 
     for marker in markers:
         directive = rf"skip doccmd[{marker}]"
-        directives = [*directives, directive]
+        directives.append(directive)
     return directives
 
 
@@ -810,7 +810,7 @@ def _process_file_path(
     content_bytes = file_path.read_bytes()
     content_str = content_bytes.decode(encoding=encoding)
     newline = _detect_newline(content=content_str)
-    sybils_with_makers: Sequence[_SybilWithTempFileMaker] = []
+    sybils_with_makers: list[_SybilWithTempFileMaker] = []
     for code_block_language in languages:
         temporary_file_extension = _get_temporary_file_extension(
             language=code_block_language,
@@ -838,7 +838,7 @@ def _process_file_path(
             newline=newline,
             parse_sphinx_jinja2=False,
         )
-        sybils_with_makers = [*sybils_with_makers, sybil_with_maker]
+        sybils_with_makers.append(sybil_with_maker)
 
     if sphinx_jinja2:
         temporary_file_extension = (
@@ -868,7 +868,7 @@ def _process_file_path(
             newline=newline,
             parse_sphinx_jinja2=True,
         )
-        sybils_with_makers = [*sybils_with_makers, sybil_with_maker]
+        sybils_with_makers.append(sybil_with_maker)
 
     try:
         _evaluate_sybils(


### PR DESCRIPTION
## Summary

- enable Astral's strictest recommended Ty rules and analysis semantics
- enable the recommended Ruff ANN, PYI, and PGH003 families
- keep preview rules explicit so existing select-all configurations do not activate unrelated preview diagnostics
- narrow straightforward typed collections and use diagnostic-specific Ty suppressions at intentionally untyped framework/data boundaries

Configuration reference: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#recommended-configuration

## Validation

- ty check
- ruff check .
- full pre-commit hook suite
