### PR TITLE
Use one sentence per line in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,9 +6,8 @@ Changelog
 2026.09.07
 ----------
 
-- Sign the macOS binary with a Developer ID certificate and notarize it, so
-  Gatekeeper no longer blocks it when it is downloaded in a browser.  The
-  ``xattr -d com.apple.quarantine`` workaround is no longer needed.
+- Sign the macOS binary with a Developer ID certificate and notarize it, so Gatekeeper no longer blocks it when it is downloaded in a browser.
+  The ``xattr -d com.apple.quarantine`` workaround is no longer needed.
 
 2026.09.01
 ----------
@@ -33,7 +32,8 @@ No significant changes.
 2026.07.19
 ----------
 
-- Reject ``--temporary-file-name-template`` values that could resolve outside the temporary directory, preventing accidental overwrite or deletion of unrelated files. See `#1211 <https://github.com/adamtheturtle/doccmd/issues/1211>`__.
+- Reject ``--temporary-file-name-template`` values that could resolve outside the temporary directory, preventing accidental overwrite or deletion of unrelated files.
+  See `#1211 <https://github.com/adamtheturtle/doccmd/issues/1211>`__.
 
 - Support configured file extensions with more than one dot (for example ``--rst-extension=.test.rst``) for both direct files and directory discovery (`#1212 <https://github.com/adamtheturtle/doccmd/issues/1212>`_).
 

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -11,19 +11,9 @@ Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-Using welcoming and inclusive language
-Being respectful of differing viewpoints and experiences
-Gracefully accepting constructive criticism
-Focusing on what is best for the community
-Showing empathy towards other community members
-Examples of unacceptable behavior by participants include:
+Using welcoming and inclusive language Being respectful of differing viewpoints and experiences Gracefully accepting constructive criticism Focusing on what is best for the community Showing empathy towards other community members Examples of unacceptable behavior by participants include:
 
-The use of sexualized language or imagery and unwelcome sexual attention or advances
-Trolling, insulting/derogatory comments, and personal or political attacks
-Public or private harassment
-Publishing others' private information, such as a physical or electronic address, without explicit permission
-Other conduct which could reasonably be considered inappropriate in a professional setting
-Our Responsibilities
+The use of sexualized language or imagery and unwelcome sexual attention or advances Trolling, insulting/derogatory comments, and personal or political attacks Public or private harassment Publishing others' private information, such as a physical or electronic address, without explicit permission Other conduct which could reasonably be considered inappropriate in a professional setting Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
@@ -32,12 +22,17 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 Scope
 -----
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+Representation of a project may be further defined and clarified by project maintainers.
 
 Enforcement
 -----------
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at adamdangoor@gmail.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at adamdangoor@gmail.com.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,8 @@ Use ``--norg-extension`` if you need additional suffixes.
    echo "Hello, Norg!"
    @end
 
-* Want more? Open an issue!
+* Want more?
+  Open an issue!
 
 Formatters and padding
 ----------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,7 +57,8 @@ What does it work on?
    console.log("Hello, MDX!")
    ```
 
-* Want more? Open an issue!
+* Want more?
+  Open an issue!
 
 Formatters and padding
 ----------------------


### PR DESCRIPTION
## Summary

- Reflow Markdown and reStructuredText prose so each sentence occupies one source line.
- Preserve tables, directives, code blocks, and vendored content.

## Validation
- Pinned Vale prose check
- Pandoc render-equivalence comparison
- git diff --check