### PR TITLE
Ban operator.attrgetter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ lint.unfixable = [
     "ERA001",
 ]
 lint.external = [ "NOD" ]
+lint.flake8-tidy-imports.banned-api."operator.attrgetter".msg = "operator.attrgetter is banned: use a lambda instead."
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = """\
     typing.cast is banned: use explicit type narrowing or a typed variable instead.\
     """


### PR DESCRIPTION
## Summary

- ban `operator.attrgetter` through Ruff's banned API configuration
- direct callers to use an explicit lambda

## Validation

- `pyproject-fmt --check pyproject.toml`
- `ruff check .`