### PR TITLE
Remove uncovered PTY choice repr

### DIFF
--- a/src/doccmd/__init__.py
+++ b/src/doccmd/__init__.py
@@ -544,10 +544,6 @@ class _UsePty(StrEnum):
     NO = auto()
     DETECT = auto()
 
-    def __repr__(self) -> str:  # pragma: no cover
-        """String representation used by ``sphinx-click``."""
-        return self.value
-
     def use_pty(self) -> bool:
         """Whether to use a pseudo-terminal."""
         if self is _UsePty.DETECT:
@@ -1691,7 +1687,7 @@ def _get_sybil(
         "--use-pty",
         "use_pty_option",
         type=click.Choice(choices=_UsePty, case_sensitive=False),
-        default=_UsePty.DETECT,
+        default=_UsePty.DETECT.name,
         show_default=True,
         help=(
             "Whether to use a pseudo-terminal for running commands. "


### PR DESCRIPTION
## Summary

- remove the private uncovered `_UsePty.__repr__` implementation
- pass the enum member name as the Click default, preserving the documented `DETECT` help text

## Validation

- `uv run prek run --all-files`
- `uv run prek run --all-files --hook-stage pre-push`
- `uv run --group=dev pytest -q --cov-fail-under=100 --cov=src/ --cov=tests .` (180 passed; 100% coverage)
